### PR TITLE
Allow multiple GH-Pages deployments in forks

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "clean": "gatsby clean",
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\" && exit 0",
     "deploy": "gatsby build --prefix-paths && gh-pages -d public -m 'Updates: Manual build'",
-    "deploy-fork": "PATH_PREFIX=\"/operate-first.github.io/$(git branch --show-current)\" gatsby build --prefix-paths && gh-pages -d public -a -e $(git branch --show-current) -m 'Preview Fork: Manual build' ",
+    "deploy-fork": "PATH_PREFIX='/operate-first.github.io' gatsby build --prefix-paths && gh-pages -d public -m 'Preview Fork: Manual build' ",
+    "deploy-branch": "PATH_PREFIX=\"/operate-first.github.io/$(git branch --show-current)\" gatsby build --prefix-paths && gh-pages -d public -a -e $(git branch --show-current) -m 'Preview Fork: Manual build of a branch' ",
     "travis-deploy": "gatsby build --prefix-paths && gh-pages -d public -r https://$GH_TOKEN@github.com/operate-first/operate-first.github.io.git -m \"Updates $TRAVIS_COMMIT: $TRAVIS_COMMIT_MESSAGE\""
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "clean": "gatsby clean",
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\" && exit 0",
     "deploy": "gatsby build --prefix-paths && gh-pages -d public -m 'Updates: Manual build'",
-    "deploy-fork": "PATH_PREFIX='/operate-first.github.io' gatsby build --prefix-paths && gh-pages -d public -m 'Preview Fork: Manual build' ",
+    "deploy-fork": "PATH_PREFIX=\"/operate-first.github.io/$(git branch --show-current)\" gatsby build --prefix-paths && gh-pages -d public -a -e $(git branch --show-current) -m 'Preview Fork: Manual build' ",
     "travis-deploy": "gatsby build --prefix-paths && gh-pages -d public -r https://$GH_TOKEN@github.com/operate-first/operate-first.github.io.git -m \"Updates $TRAVIS_COMMIT: $TRAVIS_COMMIT_MESSAGE\""
   },
   "dependencies": {

--- a/scripts/gh-pages-branch-fork.sh
+++ b/scripts/gh-pages-branch-fork.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 printf "\n\n######## build & deploy GitHub Pages from a fork ########\n"
-printf "\n## Warning: Overwrites everything in your fork's gh-pages branch.\n\n"
+printf "\n## Info: Non-destructive build. Result is deployed on \"gh-pages\" branch in \"$(git branch --show-current)\" folder.\n\n"
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
@@ -9,4 +9,4 @@ pwd
 
 npm install
 npm run build
-npm run deploy-fork
+npm run deploy-branch


### PR DESCRIPTION
Follow up on #20
Resolves #11 

Deploys a gh-pages build to a folder in the `gh-pages` branch. This folder is named after the current active local branch:
https://github.com/tumido/operate-first.github.io/tree/gh-pages

![image](https://user-images.githubusercontent.com/7453394/93583702-87694f80-f9a4-11ea-86a2-a1b1f1536955.png)

With prefixes set on the built site to also expect this subfolder we can get multiple gh-pages instances from a single repo, one instance per branch:

- `./scripts/gh-pages-fork.sh` run on `example-pr-deployment` local branch results in:
  https://tumido.github.io/operate-first.github.io/example-pr-deployment/

- `./scripts/gh-pages-fork.sh` run on `different-pr-deployment` local branch results in:
  https://tumido.github.io/operate-first.github.io/different-pr-deployment/

This was achieved by:
- Instructing `gh-pages` to [`-a` add files](https://github.com/tschaub/gh-pages#optionsadd) to the repo and don't overwrite whole repo
- Instructing `gh-pages` to use a [`-e` destination sub path](https://github.com/tschaub/gh-pages#optionsdest) in the `gh-pages` branch.
- Additionally the `PATH_PREFIX` for Gatsby was updated to respect the one more level of nesting.  