### PR TITLE
Change code blocks' backgroung to white.

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,2 +1,3 @@
 // custom typefaces
 import "prismjs/themes/prism.css";
+import "./src/styles/global.css";

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,0 +1,4 @@
+code[class*="language-"],
+pre[class*="language-"] {
+      background: white;
+}


### PR DESCRIPTION
Code blocks should have a different color to the default background.

Before:
![bef-2020-09-21_20-13](https://user-images.githubusercontent.com/51095/93804725-02ea2b80-fc47-11ea-9269-e60fbaba8279.png)

After:
![aftr-2020-09-21_20-13](https://user-images.githubusercontent.com/51095/93804740-067db280-fc47-11ea-8de9-cfe029403990.png)
