### PR TITLE
added configuration file analysis blog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Remote content
 continuous-deployment
+configuration-files-analysis
 
 # Logs
 logs

--- a/content-sources.yaml
+++ b/content-sources.yaml
@@ -16,3 +16,9 @@
   urlPrefix: cd
   ignore:
     - '**/README.md'
+
+- name: configuration file analysis
+  gitSrc: https://github.com/aicoe-aiops/configuration-files-analysis.git
+  dir: configuration-files-analysis/docs/blog
+  urlPrefix: config-analysis
+

--- a/content/toc.yaml
+++ b/content/toc.yaml
@@ -19,6 +19,9 @@
     - id: categorical-encoding
       label: Categorical Encoding
       href: /advanced-topics/categorical-encoding
+    - id: configuration-file-analysis
+      label: Configuration File Analysis
+      href: /config-analysis/configuration-file-analysis-blog
 - id: resources
   label: Resources
   href: /resources


### PR DESCRIPTION
This PR will add entry in toc.yaml and content-sources.yaml files for configuration file analysis blog. 
We used remote repo([src](https://github.com/aicoe-aiops/configuration-files-analysis)) for adding this blog. 
I tested the site locally and it looks as expected. 