### PR TITLE
Ignore continuous-deployment README.md

### DIFF
--- a/content-sources.yaml
+++ b/content-sources.yaml
@@ -14,3 +14,5 @@
   gitSrc: https://github.com/operate-first/continuous-deployment.git
   dir: continuous-deployment/docs
   urlPrefix: cd
+  ignore:
+    - '**/README.md'


### PR DESCRIPTION
continuous-deployment/docs contained README.md files which were not intended for publication and were throwing mdx compilation errors.

https://github.com/operate-first/operate-first.github.io/issues/16#issuecomment-713722463