### PR TITLE
enable aicoe-ci to assist with builds

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -1,0 +1,9 @@
+check:
+  - thoth-build
+build:
+  base-image: "registry.access.redhat.com/ubi8/nodejs-12"
+  build-stratergy: Source
+  registry: quay.io
+  registry-org: aicoe
+  registry-project: operate-first-app
+  registry-secret: aicoe-pusher-secret


### PR DESCRIPTION
Related-to: #16 
enable aicoe-ci to assist with builds
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

This would enable aicoe-ci to build an image based on the s2i method and push to aicoe quay. 
This event would be triggered on tag release. 

Performed a tag release from my fork repository, to demo/test out this feature. 
https://quay.io/repository/aicoe/operate-first-app?tab=tags

Please let me know who should be admins of the quay repository. 

Requirements:
- configure aicoe-ci for this repository: https://github.com/apps/aicoe-ci

