### PR TITLE
Add continuous deployment docs

### DIFF
--- a/content-sources.yaml
+++ b/content-sources.yaml
@@ -17,7 +17,7 @@
 
 - name: continuous deployment docs
   gitSrc: https://github.com/operate-first/continuous-deployment.git
-  dir: continuous-deployment/docs/publish
+  dir: continuous-deployment/docs
   urlPrefix: cd
   ignore:
     - "**/README.md"

--- a/content/cd-toc.yaml
+++ b/content/cd-toc.yaml
@@ -1,6 +1,39 @@
-- id: continuous-deployment
-  label: Continuous Deployment
+- id: argocd
+  label: ArgoCD Operations
+  links: 
+    - id: argocd-application-manifests
+      label: Create ArgoCD Application Manifest
+      href: /cd/create_argocd_application_manifest
+    - id: argocd-manage-app
+      label: Get ArgoCD to Manage your app
+      href: /cd/get_argocd_to_manage_your_app
+    - id: argocd-access-project
+      label: Give ArgoCD Access to your Project
+      href: /cd/give_argocd_access_to_your_project
+    - id: argocd-inclusions
+      label: Inclusions Explained
+      href: /cd/inclusions_explained
+    - id: argocd-setup
+      label: ArgoCD Setup
+      href: /cd/setup_argocd_dev_environment
+- id: crc
+  label: CRC
   links:
-    - id: versions
-      label: Versions
-      href: /cd/versions
+    - id: crc-setup
+      label: CRC Setup
+      href: /cd/downstream/crc
+    - id: crc-odh
+      label: Installing ODH on CRC
+      href: /cd/downstream/odh-install-crc
+    - id: crc-disk
+      label: CRC Disk Size
+      href: /cd/downstream/crc-disk-size
+- id: quicklab
+  label: Quicklab
+  links:
+    - id: quicklab-setup
+      label: Quicklab Setup
+      href: /cd/downstream/quicklab
+    - id: quicklab-odh
+      label: Installing ODH on Quicklab
+      href: /cd/downstream/odh-install-quicklab


### PR DESCRIPTION
Adding continuous deployment docs (#38)
You can view the changes here: https://hemajv.github.io/operate-first.github.io/

@cfchase Links within docs do not seem to get rendered. For eg in https://hemajv.github.io/operate-first.github.io/cd-quicklab/odh-install-quicklab:
1. there is a link for "CRC" which should point to https://hemajv.github.io/operate-first.github.io/cd-crc/odh-install-crc, but currently it displays `Not Found` error
2. there is a link for "quicklab guide" which should point to https://hemajv.github.io/operate-first.github.io/cd-quicklab/quicklab, but currently takes us to an unrendered doc (https://hemajv.github.io/operate-first.github.io/7fb3928919f32e906f3fe0dd38c98dbd/quicklab.md)

should I be structuring the directories in a different way?