### PR TITLE
Adds "AI for CI" initial project doc to operate first website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Remote content
 continuous-deployment
 configuration-files-analysis
+ocp-ci-analysis
 
 # Logs
 logs

--- a/content-sources.yaml
+++ b/content-sources.yaml
@@ -21,4 +21,12 @@
   gitSrc: https://github.com/aicoe-aiops/configuration-files-analysis.git
   dir: configuration-files-analysis/docs/blog
   urlPrefix: config-analysis
+  
+- name: AI for continuous integration
+  gitSrc: https://github.com/aicoe-aiops/ocp-ci-analysis.git
+  dir: ocp-ci-analysis/docs/publish
+  urlPrefix: aici
+
+
+
 

--- a/content/toc.yaml
+++ b/content/toc.yaml
@@ -22,6 +22,9 @@
     - id: configuration-file-analysis
       label: Configuration File Analysis
       href: /config-analysis/configuration-file-analysis-blog
+    - id: aici
+      label: AI for CI
+      href: /aici/project-doc
 - id: resources
   label: Resources
   href: /resources


### PR DESCRIPTION
In an effort to start making the work we are doing public via the operate first website, I've added the initial project doc for our ocp ci analysis project, which contains links to issues and notebooks. 

I've also added this with the remote content source method, so it should update as we update our source repo.  

The changes can be previewed [here](https://michaelclifford.github.io/operate-first.github.io/aici/project-doc) in the "advanced topics" tab on the "AI for CI" link. 