### PR TITLE
Workaround for podman s2i builds

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,4 +6,20 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 echo "Building ${IMAGE_REPOSITORY} from ${SOURCE_REPOSITORY_URL} on ${SOURCE_REPOSITORY_REF}"
 
 #TODO currently using node + gatsby serve.  Can switch to building assets and serving via nginx/httpd but requires a custom builder or chained build.
-s2i build ${SOURCE_REPOSITORY_URL} --ref ${SOURCE_REPOSITORY_REF} --context-dir / registry.access.redhat.com/ubi8/nodejs-12 ${IMAGE_REPOSITORY}
+if ! command -v ${CONTAINER_BUILDER} &>/dev/null; then
+    echo "CONTAINER_BUILDER=${CONTAINER_BUILDER} doen't match any available executable, exiting."
+    exit 1
+elif [ ${CONTAINER_BUILDER} == 'docker' ] && docker version 2>&1 | grep -q podman; then
+    echo "CONTAINER_BUILDER=${CONTAINER_BUILDER} is emulated via 'podman', enabling podman s2i workarounds."
+    CONTAINER_BUILDER='podman'
+fi
+
+echo "Building via CONTAINER_BUILDER=${CONTAINER_BUILDER}"
+
+if [ ${CONTAINER_BUILDER} == 'podman' ]; then
+    mkdir -p build
+    s2i build ${SOURCE_REPOSITORY_URL} --ref ${SOURCE_REPOSITORY_REF} --context-dir / registry.access.redhat.com/ubi8/nodejs-12 ${IMAGE_REPOSITORY} --as-dockerfile build/Dockerfile
+    podman build ./build -t ${IMAGE_REPOSITORY}
+else
+    s2i build ${SOURCE_REPOSITORY_URL} --ref ${SOURCE_REPOSITORY_REF} --context-dir / registry.access.redhat.com/ubi8/nodejs-12 ${IMAGE_REPOSITORY}
+fi


### PR DESCRIPTION
Fixes #63 

Apply podman workarounds if it's selected as the `CONTAINER_BUILDER` or if it emulates `docker`.

S2I is unable to fix this for over year and half... https://github.com/openshift/source-to-image/issues/966 They have a workaround available though, a `---as-dockerfile` option. This makes `s2i` create a `Dockerfile` instead of building the image directly. This `Dockerfile` can be later used to build the target via `podman`/`buildah`.   

@cfchase  please verify it still builds with docker
@goern can you please try out against the fedora's podman if this builds using the podman workarounds