### PR TITLE
modified moc repo url

### DIFF
--- a/content-sources.yaml
+++ b/content-sources.yaml
@@ -33,6 +33,6 @@
   urlPrefix: moc-cnv
 
 - name: MOC user docs
-  gitSrc: https://github.com/operate-first/odh-moc-support
+  gitSrc: https://github.com/operate-first/odh-moc-support.git
   dir: odh-moc-support/docs/user-docs
   urlPrefix: odh-moc-user


### PR DESCRIPTION
fixed repo url for https://github.com/operate-first/odh-moc-support which was causing build from previous MR #61 to fail 