### PR TITLE
Add content from data-science-workflow repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ configuration-files-analysis
 ocp-ci-analysis
 moc-cnv-sandbox
 odh-moc-support
+data-science-workflows
 
 # Logs
 logs

--- a/content-sources.yaml
+++ b/content-sources.yaml
@@ -36,3 +36,9 @@
   gitSrc: https://github.com/operate-first/odh-moc-support.git
   dir: odh-moc-support/docs/user-docs
   urlPrefix: odh-moc-user
+
+- name: Data Science Workflow
+  gitSrc: https://github.com/aicoe-aiops/data-science-workflows.git
+  dir: data-science-workflows/docs/publish
+  urlPrefix: dsw
+

--- a/content/dsw-toc.yaml
+++ b/content/dsw-toc.yaml
@@ -1,0 +1,16 @@
+- id: data-science-workflow
+  label: Data Science Workflow
+  links:
+    - id: data-science-workflow-overview
+      label: Data Science Workflow Overview
+      href: /dsw/data-science-workflow-overview
+
+    - id: project-document-template
+      label: Project Template
+      href: /dsw/project-document-template
+
+
+
+
+
+

--- a/toc-sources.yaml
+++ b/toc-sources.yaml
@@ -6,3 +6,4 @@
 - content/cd-toc.yaml # using file from local repo
 #- continuous-deployment/docs/toc.yaml # using file from cloned repo
 - content/moc-toc.yaml
+- content/dsw-toc.yaml  


### PR DESCRIPTION
This PR is related to [this issue](https://github.com/aicoe-aiops/data-science-workflows/issues/21) in the data science workflow repo.

This is an initial PR to set up https://github.com/aicoe-aiops/data-science-workflows.git as a remote content source for the operate first website. 

It adds a new drop down section to the table of contents called "Data Science Workflow", that currently contains the "getting started" and "project template" docs. The larger "project structure" document needs a small amount of editing to make it relevent to the Op1st audience, I will include those changes in a forthcoming PR. 

Please see an example here: https://michaelclifford.github.io/operate-first.github.io/operate-first  
