### PR TITLE
script to clean local dev env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,13 @@ dev:
 	./scripts/dev.sh
 
 ##################################
+# DEV-CLEAN - cleans local development environment
+
+.PHONY: dev-clean
+dev-clean:
+	./scripts/dev-clean.sh
+
+##################################
 
 # GH-PAGES - build app and deploy to GitHub pages
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ In terminal:
 make dev
 ```
 
-Runs `npm install` and `npm start`/`gatsby develop`;
+If you have problems, run `make dev-clean`
 
 #### Previewing your changes on GitHub pages
 

--- a/scripts/dev-clean.sh
+++ b/scripts/dev-clean.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+printf "\n\n######## cleaning local dev environment ########\n"
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+ENV_FILE=${DIR}/../../.env.dev
+if [ -f "${ENV_FILE}" ]; then
+  source ${ENV_FILE}
+  for ENV_VAR in $(sed 's/=.*//' ${ENV_FILE}); do export "${ENV_VAR}"; done
+fi
+
+cd ${DIR}/..
+pwd
+
+npm install
+rm -rf .cache


### PR DESCRIPTION
In case `make dev` does not work. Cleaning the `.cache` and running `npm install` again fixed the problems.
This change wraps those commands in a script