### PR TITLE
text align in navigation buttons left

### DIFF
--- a/src/components/Layout/Layout.scss
+++ b/src/components/Layout/Layout.scss
@@ -6,4 +6,8 @@
       height: 36px;
     }
   }
+
+  .pf-c-nav__link {
+    text-align: left;
+  }
 }


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/161888/98821388-c9a48f80-242f-11eb-9eff-2e96dfb77ff8.png)

after:
![image](https://user-images.githubusercontent.com/161888/98821356-bbef0a00-242f-11eb-89d1-e86c72c6bd7a.png)

cc @cfchase 