### PR TITLE
fixed blueprint repo urls

### DIFF
--- a/content-sources.yaml
+++ b/content-sources.yaml
@@ -58,4 +58,4 @@
   ignore:
     - "template.md"
     - "**/README.md"
-  urlPrefix: blueprint
+  urlPrefix: adr

--- a/content/blueprint-toc.yaml
+++ b/content/blueprint-toc.yaml
@@ -3,10 +3,10 @@
   links:
     - id: blueprint-adr-0000
       label: Use Markdown Architectural Decision Records
-      href: /blueprint/docs/adr/0000-use-markdown-architectural-decision-records
+      href: /blueprint/0000-use-markdown-architectural-decision-records
     - id: blueprint-adr-0001
       label: Use GNU GPL as license
-      href: /blueprint/docs/adr/0001-use-gpl3-as-license
+      href: /blueprint/0001-use-gpl3-as-license
     - id: blueprint-adr-0003
       label: Operate First deployment feature selection Policy
-      href: /blueprint/docs/adr/0003-feature-selection-policy
+      href: /blueprint/0003-feature-selection-policy

--- a/content/blueprint-toc.yaml
+++ b/content/blueprint-toc.yaml
@@ -3,10 +3,10 @@
   links:
     - id: blueprint-adr-0000
       label: Use Markdown Architectural Decision Records
-      href: /blueprint/0000-use-markdown-architectural-decision-records
+      href: /adr/0000-use-markdown-architectural-decision-records
     - id: blueprint-adr-0001
       label: Use GNU GPL as license
-      href: /blueprint/0001-use-gpl3-as-license
+      href: /adr/0001-use-gpl3-as-license
     - id: blueprint-adr-0003
       label: Operate First deployment feature selection Policy
-      href: /blueprint/0003-feature-selection-policy
+      href: /adr/0003-feature-selection-policy


### PR DESCRIPTION
modified urls in blueprint toc
my gh pages preview: https://oindrillac.github.io/operate-first.github.io/blueprint/0000-use-markdown-architectural-decision-records

fixes #88 

![image](https://user-images.githubusercontent.com/32435206/98950593-3159e980-24c7-11eb-9e56-46f015475b97.png)
