### PR TITLE
Adds notebook content from ocp-ci project

### DIFF
--- a/content-sources.yaml
+++ b/content-sources.yaml
@@ -32,6 +32,11 @@
   dir: ocp-ci-analysis/docs/publish
   urlPrefix: aici
 
+- name: AI for continuous integration notebooks
+  gitSrc: https://github.com/aicoe-aiops/ocp-ci-analysis.git
+  dir: ocp-ci-analysis/notebooks
+  urlPrefix: aici-nb
+
 - name: MOC onboarding docs
   gitSrc: https://gitlab.com/open-infrastructure-labs/moc-cnv-sandbox.git
   dir: moc-cnv-sandbox/docs

--- a/content/aici-toc.yaml
+++ b/content/aici-toc.yaml
@@ -1,0 +1,16 @@
+- id: AI-for-CI
+  label: AI for Continuous Integration
+  links:
+    - id: ai-for-ci-overview
+      label: AI for Continuous Integration Overview
+      href: /aici/project-doc
+
+    - id: testgrid-EDA
+      label: Initial TestGrid EDA
+      href: /aici-nb/testgrid-eda
+
+    - id: testgrid-indepth-eda
+      label: Indepth TestGrid EDA
+      href: /aici-nb/testgrid-eda-indepth
+
+

--- a/content/toc.yaml
+++ b/content/toc.yaml
@@ -16,9 +16,6 @@
     - id: configuration-file-analysis
       label: Configuration File Analysis
       href: /config-analysis/configuration-file-analysis-blog
-    - id: aici
-      label: AI for CI
-      href: /aici/project-doc
 - id: resources
   label: Resources
   href: /resources

--- a/toc-sources.yaml
+++ b/toc-sources.yaml
@@ -9,3 +9,4 @@
 #- continuous-deployment/docs/toc.yaml # using file from cloned repo
 - content/moc-toc.yaml
 - content/dsw-toc.yaml
+- content/aici-toc.yaml


### PR DESCRIPTION
This PR  is related to [this issue](https://github.com/aicoe-aiops/ocp-ci-analysis/issues/34), and adds two content notebooks from the [OpenShift CI project](https://github.com/aicoe-aiops/ocp-ci-analysis), as well as consolidates all of the content related to that project to a single drop-down called "AI for Continuous Integration". Some of this content is still being polished, the main purpose of this PR is to set up the remote connection between repos so that any additional edits to the project are reflected directly in the op1st website.   

You can preview the changes [here](https://michaelclifford.github.io/operate-first.github.io/aici/operate-first) 
