### PR TITLE
Added contribute page

### DIFF
--- a/content/contribute-toc.yaml
+++ b/content/contribute-toc.yaml
@@ -1,0 +1,3 @@
+- id: contribute
+  label: Contribute
+  href: /contribute

--- a/content/contribute/index.md
+++ b/content/contribute/index.md
@@ -1,0 +1,6 @@
+---
+title: Contribute to Operate First
+description: "How to contribute to operate first"
+---
+
+To contribute to the Operate First initiative, seek support or report bugs on the website, please open an issue [here](https://github.com/operate-first/operate-first.github.io/issues).

--- a/toc-sources.yaml
+++ b/toc-sources.yaml
@@ -10,3 +10,4 @@
 - content/moc-toc.yaml
 - content/dsw-toc.yaml
 - content/aici-toc.yaml
+- content/contribute-toc.yaml


### PR DESCRIPTION
Added contribute page at the bottom of toc. 
Preview: https://oindrillac.github.io/operate-first.github.io/contribute

Addresses #57 

We would still need to add a footer at the bottom for an imprint - can be addressed in a separate issue.
