### PR TITLE
added failure type classification with testgrid data project doc to "AI for Continuous integration"

### DIFF
--- a/content/aici-toc.yaml
+++ b/content/aici-toc.yaml
@@ -5,6 +5,10 @@
       label: AI for Continuous Integration Overview
       href: /aici/project-doc
 
+    - id: ci-failure-type-classification
+      label: Failure type classification with the TestGrid
+      href: /aici/failure-type-classification-with-the-testgrid-data-project-doc
+
     - id: testgrid-EDA
       label: Initial TestGrid EDA
       href: /aici-nb/testgrid-eda


### PR DESCRIPTION
This PR addresses [issue](https://github.com/aicoe-aiops/ocp-ci-analysis/issues/34)
I added "failure type classification with testgrid data" project doc to "AI for Continuous integration" section. 

Currently, the size of the image in the doc is small. I will update the doc once issue #111 is resolved.

You can preview the doc over [here](https://sankbad.github.io/operate-first.github.io/aici/failure-type-classification-with-the-testgrid-data-project-doc