### PR TITLE
replace custom git clone logic with gatsby plugin

### DIFF
--- a/content-sources.yaml
+++ b/content-sources.yaml
@@ -10,13 +10,6 @@
 - name: local content
   dir: content
 
-- name: continuous delivery docs
-  gitSrc: https://github.com/operate-first/continuous-delivery.git
-  dir: continuous-delivery
-  ignore: 
-    - "**/*.yaml"
-  urlPrefix: blueprints/continuous-delivery
-
 - name: continuous deployment docs
   gitSrc: https://github.com/operate-first/continuous-deployment.git
   dir: continuous-deployment

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -76,6 +76,14 @@ let config = {
     `gatsby-transformer-yaml`,
     `gatsby-plugin-meta-redirect`,
     `@rafaelquintanilha/gatsby-transformer-ipynb`,
+    {
+      resolve: `gatsby-source-git`,
+      options: {
+        name: `blueprints/continuous-delivery`,
+        remote: `https://github.com/operate-first/continuous-delivery.git`,
+        patterns: `**/*md`,
+      }
+    },
   ],
 };
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -7,21 +7,22 @@ const contentSources = yaml.safeLoad(fs.readFileSync(`./content-sources.yaml`, `
 const tocSources = yaml.safeLoad(fs.readFileSync(`./toc-sources.yaml`, `utf-8`));
 
 exports.onCreateNode = ({ node, getNode, actions }) => {
-  const { createNodeField } = actions
+  const { createNodeField, getParent } = actions
   if (node.internal.type === "Mdx") {
-    // // Use `createFilePath` to turn markdown files in our `data/faqs` directory into `/faqs/slug`
-    // const relativeFilePath = createFilePath({
-    //   node,
-    //   getNode,
-    //   basePath: "data/faqs/",
-    // })
-
-    // // Creates new query'able field with name of 'slug'
-    // createNodeField({
-    //   node,
-    //   name: "slug",
-    //   value: `/faqs${relativeFilePath}`,
-    // })
+    const fileNode = getNode(node.parent);
+    const gitRemoteNode = getNode(fileNode.gitRemote___NODE);
+    if (gitRemoteNode) {
+      const relativeFilePath = createFilePath({
+        node,
+        getNode,
+        basePath: "",
+      })
+      createNodeField({
+        node,
+        name: "slug",
+        value: gitRemoteNode.sourceInstanceName + `${relativeFilePath}`,
+      })
+    }
   }
 }
 
@@ -41,6 +42,9 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
               frontmatter {
                 title
               }
+              fields {
+                slug
+              }
             }
           }
         }
@@ -53,12 +57,17 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
   }
 
   const mdx = result.data.allMdx.edges;
+  let page_path = "";
 
   mdx.forEach(({ node }, index) => {
     if (node.slug) {
+      if (node.fields && node.fields.slug) {
+        page_path = node.fields.slug;
+      } else {
+        page_path = createPagePath(node);
+      }
       createPage({
-        path: createPagePath(node),
-        // path: node.slug,
+        path: page_path,
         component: docTemplate,
         context: {
           id: node.id,

--- a/package-lock.json
+++ b/package-lock.json
@@ -2122,6 +2122,15 @@
       "resolved": "https://registry.npmjs.org/@mikaelkristiansson/domready/-/domready-1.0.10.tgz",
       "integrity": "sha512-6cDuZeKSCSJ1KvfEQ25Y8OXUjqDJZ+HgUs6dhASWbAX8fxVraTfPsSeRe2bN+4QJDsgUaXaMWBYfRomCr04GGg=="
     },
+    "@mrmlnc/readdir-enhanced": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
+      "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
+      "requires": {
+        "call-me-maybe": "^1.0.1",
+        "glob-to-regexp": "^0.3.0"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
@@ -5150,6 +5159,11 @@
           "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
         }
       }
+    },
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
     },
     "caller-callsite": {
       "version": "2.0.0",
@@ -10854,6 +10868,57 @@
         }
       }
     },
+    "gatsby-source-git": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/gatsby-source-git/-/gatsby-source-git-1.1.0.tgz",
+      "integrity": "sha512-f5HllxwS+ivVn6SitSJPEQe8tf/apjwq5TOZRiEIRJtlrm9eSBqM2hO6ZIOK5na6UuvI+BH8xxbgj0qrwNTznA==",
+      "requires": {
+        "fast-glob": "^2.2.3",
+        "fs-extra": "^5.0.0",
+        "gatsby-source-filesystem": "^2.1.19",
+        "git-url-parse": "^11.1.1",
+        "rimraf": "^2.6.2",
+        "simple-git": "^1.105.0"
+      },
+      "dependencies": {
+        "@nodelib/fs.stat": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
+          "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
+        },
+        "fast-glob": {
+          "version": "2.2.7",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz",
+          "integrity": "sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==",
+          "requires": {
+            "@mrmlnc/readdir-enhanced": "^2.2.1",
+            "@nodelib/fs.stat": "^1.1.2",
+            "glob-parent": "^3.1.0",
+            "is-glob": "^4.0.0",
+            "merge2": "^1.2.3",
+            "micromatch": "^3.1.10"
+          }
+        },
+        "fs-extra": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+          "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
     "gatsby-telemetry": {
       "version": "1.3.35",
       "resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-1.3.35.tgz",
@@ -11135,6 +11200,14 @@
         "parse-url": "^5.0.0"
       }
     },
+    "git-url-parse": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.4.0.tgz",
+      "integrity": "sha512-KlIa5jvMYLjXMQXkqpFzobsyD/V2K5DRHl5OAf+6oDFPlPLxrGDVQlIdI63c4/Kt6kai4kALENSALlzTGST3GQ==",
+      "requires": {
+        "git-up": "^4.0.0"
+      }
+    },
     "github-from-package": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
@@ -11186,6 +11259,11 @@
           }
         }
       }
+    },
+    "glob-to-regexp": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+      "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs="
     },
     "global": {
       "version": "4.4.0",
@@ -19935,6 +20013,24 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
           "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
+        }
+      }
+    },
+    "simple-git": {
+      "version": "1.132.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.132.0.tgz",
+      "integrity": "sha512-xauHm1YqCTom1sC9eOjfq3/9RKiUA9iPnxBbrY2DdL8l4ADMu0jjM5l5lphQP5YWNqAL2aXC/OeuQ76vHtW5fg==",
+      "requires": {
+        "debug": "^4.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "gatsby-remark-responsive-iframe": "^2.4.14",
     "gatsby-remark-smartypants": "^2.3.11",
     "gatsby-source-filesystem": "^2.3.30",
+    "gatsby-source-git": "^1.1.0",
     "gatsby-transformer-sharp": "~2.5.15",
     "gatsby-transformer-yaml": "^2.4.12",
     "js-yaml": "^3.14.0",


### PR DESCRIPTION
Uses https://github.com/stevetweeddale/gatsby-source-git to to essentially the same as the custom git clone logic to pull in remote content.
