### PR TITLE
fix(remote-content): Remove MDX exceptions

### DIFF
--- a/content/operators.yaml
+++ b/content/operators.yaml
@@ -1,6 +1,6 @@
 - id: argocd
   label: ArgoCD Operations
-  links: 
+  links:
     - id: argocd-application-manifests
       label: Create ArgoCD Application Manifest
       href: /operators/continuous-deployment/docs/create_argocd_application_manifest
@@ -34,6 +34,9 @@
     - id: quicklab-setup
       label: Quicklab Setup
       href: /operators/continuous-deployment/docs/downstream/quicklab
+    - id: quicklab-pv
+      label: Create persistent volumes
+      href: /operators/continuous-deployment/docs/downstream/on-cluster-persistent-storage/README
     - id: quicklab-odh
       label: Installing ODH on Quicklab
       href: /operators/continuous-deployment/docs/downstream/odh-install-quicklab

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -81,7 +81,7 @@ let config = {
       options: {
         name: `data-science/data-science-workflows`,
         remote: `https://github.com/aicoe-aiops/data-science-workflows.git`,
-        patterns: [`**/*.md`, `**/*.png`, `!**/Thoth-bots.md`],
+        patterns: [`**/*.md`, `**/*.png`],
       }
     },
     {
@@ -121,7 +121,7 @@ let config = {
       options: {
         name: `operators/continuous-deployment`,
         remote: `https://github.com/operate-first/continuous-deployment.git`,
-        patterns: [`**/*.md`, `**/*.png`, `!**/docs/downstream/on-cluster-persistent-storage/README.md`],
+        patterns: [`**/*.md`, `**/*.png`],
       }
     },
     {


### PR DESCRIPTION
Depends on: https://github.com/aicoe-aiops/data-science-workflows/pull/23  https://github.com/operate-first/continuous-deployment/pull/71
Reverts: https://github.com/operate-first/operate-first.github.io/pull/120

Since we treat all Markdown files as MDX (while their syntax is not fully compatible) we've introduced exceptions - which makes gatsby not process certain files - files which don't comply with MDX.

MDX can't parse invalid XHTML as well as is unable to handle Markdown/HTML comments. See:
https://github.com/mdx-js/mdx/issues/784
https://github.com/mdx-js/mdx/pull/1039
