### PR TITLE
Keep extension for .md and .ipynb files in links

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add a [gatsby-source-git](https://www.gatsbyjs.com/plugins/gatsby-source-git/) s
 The `name` for the plugin will be the prefix for URLs generated from that repository.
 In the following example, all Markdown and JupyterNotebook files will be rendered as pages under the `/data-science/ocp-ci-analysis` path.
 
-The [notebooks/TestGrid_EDA.ipynb](https://github.com/aicoe-aiops/ocp-ci-analysis/blob/master/notebooks/TestGrid_EDA.ipynb) Notebook will be rendered at [/data-science/ocp-ci-analysis/notebooks/TestGrid_EDA/](http://www.operate-first.cloud/data-science/ocp-ci-analysis/notebooks/TestGrid_EDA/).
+The [notebooks/TestGrid_EDA.ipynb](https://github.com/aicoe-aiops/ocp-ci-analysis/blob/master/notebooks/TestGrid_EDA.ipynb) Notebook will be rendered at [/data-science/ocp-ci-analysis/notebooks/TestGrid_EDA.ipynb](http://www.operate-first.cloud/data-science/ocp-ci-analysis/notebooks/TestGrid_EDA.ipynb).
 
 ### Local Content
 
@@ -47,7 +47,7 @@ Files formatted as
 
 Markdown files can be prefixed with [frontmatter](https://www.gatsbyjs.com/docs/adding-markdown-pages/#frontmatter-for-metadata-in-markdown-files). 
 
-See [/content/examples/markdown.md](/content/examples/markdown.md) rendered [here](https://www.operate-first.cloud/examples/markdown)
+See [/content/examples/markdown.md](/content/examples/markdown.md) rendered [here](https://www.operate-first.cloud/examples/markdown.md)
 
 ```markdown
 ---
@@ -64,13 +64,13 @@ valid markdown
 
 Any file with the `.ipynb` extension will be rendered as HTML. This is done via the [gatsby-transformer-ipynb](https://www.gatsbyjs.com/plugins/@rafaelquintanilha/gatsby-transformer-ipynb/).
 
-See [/content/examples/jupyter_notebook.ipynb](/content/examples/jupyter_notebook.ipynb) rendered [here](https://www.operate-first.cloud/examples/jupyter_notebook)
+See [/content/examples/jupyter_notebook.ipynb](/content/examples/jupyter_notebook.ipynb) rendered [here](https://www.operate-first.cloud/examples/jupyter_notebook.ipynb)
 
 #### MDX
 
 Similar to Markdown, but you can add [React Components](https://www.gatsbyjs.com/docs/glossary#component), which basically extend HTML. E.g. you can embedd a JupyterNotebook into the MDX file.
 
-See [/content/examples/mdx.mdx](/content/examples/mdx.mdx) rendered [here](https://www.operate-first.cloud/examples/mdx)
+See [/content/examples/mdx.mdx](/content/examples/mdx.mdx) rendered [here](https://www.operate-first.cloud/examples/mdx.mdx)
 
 
 ```markdown
@@ -83,6 +83,15 @@ This is how I include a Notebook:
 
 <JupyterNotebook path="jupyter_notebook.ipynb"/>
 ```
+
+### Linking
+
+All links should be added as relative links, i.e. they should not start with a `/`. 
+If you link to another document in your own content repository, 
+then a relative link will work when the content is rendered at GitHub *and* it will work in the gatsby site.
+
+`index.md` and `README.md` files will be treated as index files. Their name will be stripped from the URL.
+E.g. `/folder/README.md` would result in `/folder/`
 
 ### Site structure
 

--- a/README.md
+++ b/README.md
@@ -100,25 +100,19 @@ Whether adding content remotely, or locally, the content needs to be added to th
 
 The `config` directory contains `category.yaml` files for each category eg: `blueprints.yaml` for the Blueprints category and this file will contain the table of content navigation items for each document that you add.
 
-The (`.yaml`) config looks as follows:
-
 ```yaml
-- id: my-uniq-id
-  label: The Navigation Item
+- label: The Navigation Item
   href: /the/url/to/the/page
 ```
 
 Following is an example of 2 level hierarchy from a repo, for cases where you have to add more than one document from a repository as remote content.
 
 ```yaml
-- id: continuous-delivery
-  label: Continuous Delivery
+- label: Continuous Delivery
   links:
-    - id: cicd_intro
-      label: (Opinionated) Continuous Delivery
+    - label: (Opinionated) Continuous Delivery
       href: /blueprints/continuous-delivery/docs/continuous_delivery
-    - id: continuous-delivery-setup-source-operations
-      label: Setting up Source Code Operations
+    - label: Setting up Source Code Operations
       href: /blueprints/continuous-delivery/docs/setup_source_operations
 ```
 

--- a/config/blueprints.yaml
+++ b/config/blueprints.yaml
@@ -1,18 +1,18 @@
 - label: Architecture Decision Records
   links:
     - label: Use Markdown Architectural Decision Records
-      href: /blueprints/blueprint/docs/adr/0000-use-markdown-architectural-decision-records
+      href: /blueprints/blueprint/docs/adr/0000-use-markdown-architectural-decision-records.md
     - label: Use GNU GPL as license
-      href: /blueprints/blueprint/docs/adr/0001-use-gpl3-as-license
+      href: /blueprints/blueprint/docs/adr/0001-use-gpl3-as-license.md
     - label: Operate First deployment feature selection Policy
-      href: /blueprints/blueprint/docs/adr/0003-feature-selection-policy
+      href: /blueprints/blueprint/docs/adr/0003-feature-selection-policy.md
 - label: Continuous Delivery
   links:
     - label: (Opinionated) Continuous Delivery
-      href: /blueprints/continuous-delivery/docs/continuous_delivery
+      href: /blueprints/continuous-delivery/docs/continuous_delivery.md
     - label: Setting up Source Code Operations
-      href: /blueprints/continuous-delivery/docs/setup_source_operations
+      href: /blueprints/continuous-delivery/docs/setup_source_operations.md
     - label: Setting up a Continuous Integration Pipeline
-      href: /blueprints/continuous-delivery/docs/setup_ci_pipeline
+      href: /blueprints/continuous-delivery/docs/setup_ci_pipeline.md
     - label: Setting up a Continuous Delivery Pipeline
-      href: /blueprints/continuous-delivery/docs/setup_cd_pipeline
+      href: /blueprints/continuous-delivery/docs/setup_cd_pipeline.md

--- a/config/blueprints.yaml
+++ b/config/blueprints.yaml
@@ -1,27 +1,18 @@
-- id: blueprint-adr
-  label: Architecture Decision Records
+- label: Architecture Decision Records
   links:
-    - id: blueprint-adr-0000
-      label: Use Markdown Architectural Decision Records
+    - label: Use Markdown Architectural Decision Records
       href: /blueprints/blueprint/docs/adr/0000-use-markdown-architectural-decision-records
-    - id: blueprint-adr-0001
-      label: Use GNU GPL as license
+    - label: Use GNU GPL as license
       href: /blueprints/blueprint/docs/adr/0001-use-gpl3-as-license
-    - id: blueprint-adr-0003
-      label: Operate First deployment feature selection Policy
+    - label: Operate First deployment feature selection Policy
       href: /blueprints/blueprint/docs/adr/0003-feature-selection-policy
-- id: continuous-delivery
-  label: Continuous Delivery
+- label: Continuous Delivery
   links:
-    - id: cicd_intro
-      label: (Opinionated) Continuous Delivery
+    - label: (Opinionated) Continuous Delivery
       href: /blueprints/continuous-delivery/docs/continuous_delivery
-    - id: continuous-delivery-setup-source-operations
-      label: Setting up Source Code Operations
+    - label: Setting up Source Code Operations
       href: /blueprints/continuous-delivery/docs/setup_source_operations
-    - id: continuous-delivery-setup-ci
-      label: Setting up a Continuous Integration Pipeline
+    - label: Setting up a Continuous Integration Pipeline
       href: /blueprints/continuous-delivery/docs/setup_ci_pipeline
-    - id: continuous-delivery-setup-cd
-      label: Setting up a Continuous Delivery Pipeline
+    - label: Setting up a Continuous Delivery Pipeline
       href: /blueprints/continuous-delivery/docs/setup_cd_pipeline

--- a/config/data-science.yaml
+++ b/config/data-science.yaml
@@ -3,22 +3,22 @@
     - label: Projects Overview
       href: /data-science/
     - label: Categorical Encoding
-      href: /data-science/categorical-encoding/docs/blog/blog
+      href: /data-science/categorical-encoding/docs/blog/blog.md
     - label: Configuration File Analysis
-      href: /data-science/configuration-files-analysis/docs/blog/configuration-file-analysis-blog
+      href: /data-science/configuration-files-analysis/docs/blog/configuration-file-analysis-blog.md
 - label: Data Science Workflow
   links:
     - label: Data Science Workflow Overview
-      href: /data-science/data-science-workflows/README
+      href: /data-science/data-science-workflows/
     - label: Project Template
-      href: /data-science/data-science-workflows/docs/publish/project-document-template/
+      href: /data-science/data-science-workflows/docs/publish/project-document-template.md
 - label: AI for Continuous Integration
   links:
     - label: AI for Continuous Integration Overview
-      href: /data-science/ocp-ci-analysis/README
+      href: /data-science/ocp-ci-analysis/
     - label: Failure type classification with the TestGrid
-      href: /data-science/ocp-ci-analysis/docs/publish/failure-type-classification-with-the-testgrid-data-project-doc
+      href: /data-science/ocp-ci-analysis/docs/publish/failure-type-classification-with-the-testgrid-data-project-doc.md
     - label: Initial TestGrid EDA
-      href: /data-science/ocp-ci-analysis/notebooks/TestGrid_EDA/
+      href: /data-science/ocp-ci-analysis/notebooks/TestGrid_EDA.ipynb
     - label: Indepth TestGrid EDA
-      href: /data-science/ocp-ci-analysis/notebooks/TestGrid_indepth_EDA/
+      href: /data-science/ocp-ci-analysis/notebooks/TestGrid_indepth_EDA.ipynb

--- a/config/data-science.yaml
+++ b/config/data-science.yaml
@@ -1,36 +1,24 @@
-- id: data-science
-  label: Data Science Projects
+- label: Data Science Projects
   links:
-    - id: projects-overview
-      label: Projects Overview
+    - label: Projects Overview
       href: /data-science/
-    - id: categorical-encoding
-      label: Categorical Encoding
+    - label: Categorical Encoding
       href: /data-science/categorical-encoding/docs/blog/blog
-    - id: configuration-file-analysis
-      label: Configuration File Analysis
+    - label: Configuration File Analysis
       href: /data-science/configuration-files-analysis/docs/blog/configuration-file-analysis-blog
-- id: data-science-workflow
-  label: Data Science Workflow
+- label: Data Science Workflow
   links:
-    - id: data-science-workflow-overview
-      label: Data Science Workflow Overview
+    - label: Data Science Workflow Overview
       href: /data-science/data-science-workflows/README
-    - id: project-document-template
-      label: Project Template
+    - label: Project Template
       href: /data-science/data-science-workflows/docs/publish/project-document-template/
-- id: AI-for-CI
-  label: AI for Continuous Integration
+- label: AI for Continuous Integration
   links:
-    - id: ai-for-ci-overview
-      label: AI for Continuous Integration Overview
+    - label: AI for Continuous Integration Overview
       href: /data-science/ocp-ci-analysis/README
-    - id: ci-failure-type-classification
-      label: Failure type classification with the TestGrid
+    - label: Failure type classification with the TestGrid
       href: /data-science/ocp-ci-analysis/docs/publish/failure-type-classification-with-the-testgrid-data-project-doc
-    - id: testgrid-EDA
-      label: Initial TestGrid EDA
+    - label: Initial TestGrid EDA
       href: /data-science/ocp-ci-analysis/notebooks/TestGrid_EDA/
-    - id: testgrid-indepth-eda
-      label: Indepth TestGrid EDA
+    - label: Indepth TestGrid EDA
       href: /data-science/ocp-ci-analysis/notebooks/TestGrid_indepth_EDA/

--- a/config/operators.yaml
+++ b/config/operators.yaml
@@ -1,32 +1,34 @@
-- label: ArgoCD Operations
+- label: Continous Deployment
   links:
+    - label: Opinionated reference architecture
+      href: /operators/continuous-deployment/
     - label: Create ArgoCD Application Manifest
-      href: /operators/continuous-deployment/docs/create_argocd_application_manifest
+      href: /operators/continuous-deployment/docs/create_argocd_application_manifest.md
     - label: Get ArgoCD to Manage your app
-      href: /operators/continuous-deployment/docs/get_argocd_to_manage_your_app
+      href: /operators/continuous-deployment/docs/get_argocd_to_manage_your_app.md
     - label: Give ArgoCD Access to your Project
-      href: /operators/continuous-deployment/docs/give_argocd_access_to_your_project
+      href: /operators/continuous-deployment/docs/give_argocd_access_to_your_project.md
     - label: Inclusions Explained
-      href: /operators/continuous-deployment/docs/inclusions_explained
+      href: /operators/continuous-deployment/docs/inclusions_explained.md
     - label: ArgoCD Setup
-      href: /operators/continuous-deployment/docs/setup_argocd_dev_environment
+      href: /operators/continuous-deployment/docs/setup_argocd_dev_environment.md
 - label: CRC
   links:
     - label: CRC Setup
-      href: /operators/continuous-deployment/docs/downstream/crc
+      href: /operators/continuous-deployment/docs/downstream/crc.md
     - label: Installing ODH on CRC
-      href: /operators/continuous-deployment/docs/downstream/odh-install-crc
+      href: /operators/continuous-deployment/docs/downstream/odh-install-crc.md
     - label: CRC Disk Size
-      href: /operators/continuous-deployment/docs/downstream/crc-disk-size
+      href: /operators/continuous-deployment/docs/downstream/crc-disk-size.md
 - label: Quicklab
   links:
     - label: Quicklab Setup
-      href: /operators/continuous-deployment/docs/downstream/quicklab
+      href: /operators/continuous-deployment/docs/downstream/quicklab.md
     - label: Create persistent volumes
-      href: /operators/continuous-deployment/docs/downstream/on-cluster-persistent-storage/README
+      href: /operators/continuous-deployment/docs/downstream/on-cluster-persistent-storage/
     - label: Installing ODH on Quicklab
-      href: /operators/continuous-deployment/docs/downstream/odh-install-quicklab
+      href: /operators/continuous-deployment/docs/downstream/odh-install-quicklab.md
 - label: MOC - ODH Operations
   links:
     - label: Getting Access
-      href: /operators/moc-cnv-sandbox/docs/about-the-cluster
+      href: /operators/moc-cnv-sandbox/docs/about-the-cluster.md

--- a/config/operators.yaml
+++ b/config/operators.yaml
@@ -1,48 +1,32 @@
-- id: argocd
-  label: ArgoCD Operations
+- label: ArgoCD Operations
   links:
-    - id: argocd-application-manifests
-      label: Create ArgoCD Application Manifest
+    - label: Create ArgoCD Application Manifest
       href: /operators/continuous-deployment/docs/create_argocd_application_manifest
-    - id: argocd-manage-app
-      label: Get ArgoCD to Manage your app
+    - label: Get ArgoCD to Manage your app
       href: /operators/continuous-deployment/docs/get_argocd_to_manage_your_app
-    - id: argocd-access-project
-      label: Give ArgoCD Access to your Project
+    - label: Give ArgoCD Access to your Project
       href: /operators/continuous-deployment/docs/give_argocd_access_to_your_project
-    - id: argocd-inclusions
-      label: Inclusions Explained
+    - label: Inclusions Explained
       href: /operators/continuous-deployment/docs/inclusions_explained
-    - id: argocd-setup
-      label: ArgoCD Setup
+    - label: ArgoCD Setup
       href: /operators/continuous-deployment/docs/setup_argocd_dev_environment
-- id: crc
-  label: CRC
+- label: CRC
   links:
-    - id: crc-setup
-      label: CRC Setup
+    - label: CRC Setup
       href: /operators/continuous-deployment/docs/downstream/crc
-    - id: crc-odh
-      label: Installing ODH on CRC
+    - label: Installing ODH on CRC
       href: /operators/continuous-deployment/docs/downstream/odh-install-crc
-    - id: crc-disk
-      label: CRC Disk Size
+    - label: CRC Disk Size
       href: /operators/continuous-deployment/docs/downstream/crc-disk-size
-- id: quicklab
-  label: Quicklab
+- label: Quicklab
   links:
-    - id: quicklab-setup
-      label: Quicklab Setup
+    - label: Quicklab Setup
       href: /operators/continuous-deployment/docs/downstream/quicklab
-    - id: quicklab-pv
-      label: Create persistent volumes
+    - label: Create persistent volumes
       href: /operators/continuous-deployment/docs/downstream/on-cluster-persistent-storage/README
-    - id: quicklab-odh
-      label: Installing ODH on Quicklab
+    - label: Installing ODH on Quicklab
       href: /operators/continuous-deployment/docs/downstream/odh-install-quicklab
-- id: moc-ops-docs
-  label: MOC - ODH Operations
+- label: MOC - ODH Operations
   links:
-    - id: moc-getting-access
-      label: Getting Access
+    - label: Getting Access
       href: /operators/moc-cnv-sandbox/docs/about-the-cluster

--- a/config/users.yaml
+++ b/config/users.yaml
@@ -1,9 +1,6 @@
-- id: moc
-  label: User support
+- label: User support
   href: /users/odh-moc-support/README
-- id: moc-user-docs
-  label: Components
+- label: Components
   links:
-    - id: moc-jh
-      label: JupyterHub
+    - label: JupyterHub
       href: /users/odh-moc-support/docs/user-docs/jupyterhub

--- a/config/users.yaml
+++ b/config/users.yaml
@@ -1,6 +1,6 @@
 - label: User support
-  href: /users/odh-moc-support/README
+  href: /users/odh-moc-support/
 - label: Components
   links:
     - label: JupyterHub
-      href: /users/odh-moc-support/docs/user-docs/jupyterhub
+      href: /users/odh-moc-support/docs/user-docs/jupyterhub.md

--- a/content/index.md
+++ b/content/index.md
@@ -16,19 +16,19 @@ At the Office of the CTO at Red Hat, we can lead the way with [Open Data Hub](ht
  
 ## Getting started
  
-## [Data Science](https://www.operate-first.cloud/data-science/)
+## [Data Science](/data-science/)
  
 Get started with tutorials and examples for data science on Open Data Hub.
  
-## [Users](https://www.operate-first.cloud/users/)
+## [Users](/users/)
  
 Learn how you can engage with Open Data Hub and access the deployed components.
  
-## [Operators](https://www.operate-first.cloud/operators/)
+## [Operators](/operators/)
  
 See how we are deploying and operating Open Data Hub
  
-## [Blueprints](https://www.operate-first.cloud/blueprints/)
+## [Blueprints](/blueprints/)
  
 Apply best practices and tooling to your own projects.
  

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -44,8 +44,13 @@ let config = {
               },
             },
           },
+          {
+            resolve: `gatsby-remark-copy-linked-files`,
+            options: {
+              ignoreFileExtensions: [`md`],
+            },
+          },
           `gatsby-remark-prismjs`,
-          `gatsby-remark-copy-linked-files`,
           `gatsby-remark-smartypants`,
         ],
       },

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -18,12 +18,22 @@ exports.onCreateNode = ({ node, getNode, actions }) => {
       node,
       getNode,
       basePath: "",
+      trailingSlash: false
     })
 
     if (gitRemoteNode) {
       slug = gitRemoteNode.sourceInstanceName + relativeFilePath;
     } else {
       slug = relativeFilePath;
+    }
+    // add extension, e.g. `.md` back to the URL, except for index and README
+    if (fileNode.name != "index") {
+      if (fileNode.name.toLowerCase() == "readme") {
+        // README is also like an index. Don't use it in the URL
+        slug = slug.slice(0,-6);
+      } else {
+        slug = slug + "." + fileNode.extension;
+      }
     }
 
     createNodeField({

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -2,6 +2,7 @@ const fs = require(`fs`);
 const { createFilePath } = require("gatsby-source-filesystem");
 const yaml = require(`js-yaml`);
 const path = require(`path`);
+const { nanoid } = require(`nanoid`);
 
 const contentSources = yaml.safeLoad(fs.readFileSync(`./config/content-sources.yaml`, `utf-8`));
 const tocSources = yaml.safeLoad(fs.readFileSync(`./config/toc-sources.yaml`, `utf-8`));
@@ -128,7 +129,22 @@ exports.sourceNodes = ({ actions, createNodeId, createContentDigest, reporter })
       return;
     }
     const toc = yaml.safeLoad(fs.readFileSync(fileLocation, `utf-8`));
-    toc.forEach((navItem) => navItems.push(navItem));
+
+    // adding ids to navItems
+    toc.forEach((navItem) => {
+      if (!navItem.id) {
+        navItem.id = nanoid();
+      }
+      if (navItem.links) {
+        navItem.links.forEach((link) => {
+          if (!link.id) {
+            link.id = nanoid();
+          }
+        })
+      }
+      navItems.push(navItem);
+    }); 
+
     actions.createNode({
       id: createNodeId(`NavData`),
       navItems: navItems,

--- a/package-lock.json
+++ b/package-lock.json
@@ -14794,6 +14794,11 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
       "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
     },
+    "nanoid": {
+      "version": "3.1.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.18.tgz",
+      "integrity": "sha512-rndlDjbbHbcV3xi+R2fpJ+PbGMdfBxz5v1fATIQFq0DP64FsicQdwnKLy47K4kZHdRpmQXtz24eGsxQqamzYTA=="
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -20078,9 +20083,9 @@
       }
     },
     "slugify": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.4.5.tgz",
-      "integrity": "sha512-WpECLAgYaxHoEAJ8Q1Lo8HOs1ngn7LN7QjXgOLbmmfkcWvosyk4ZTXkTzKyhngK640USTZUlgoQJfED1kz5fnQ=="
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.4.6.tgz",
+      "integrity": "sha512-ZdJIgv9gdrYwhXqxsH9pv7nXxjUEyQ6nqhngRxoAAOlmMGA28FDq5O4/5US4G2/Nod7d1ovNcgURQJ7kHq50KQ=="
     },
     "snake-case": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "gatsby-transformer-sharp": "~2.5.15",
     "gatsby-transformer-yaml": "^2.4.12",
     "js-yaml": "^3.14.0",
+    "nanoid": "^3.1.18",
     "node-sass": "^4.14.1",
     "prismjs": "^1.21.0",
     "react": "^16.13.1",


### PR DESCRIPTION
This way we can keep intra-site link working.

Before the `here` links in https://www.operate-first.cloud/operators/continuous-deployment/docs/get_argocd_to_manage_your_app would link to a `.md` file being downloaded, although it's also converted to a page.
Now it links to the rendered page.