### PR TITLE
fix(gatsby): Fix image louder blur on images with alpha

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -27,6 +27,7 @@ let config = {
             resolve: `gatsby-remark-images`,
             options: {
               maxWidth: 590,
+              disableBgImageOnAlpha: true,
             },
           },
           {


### PR DESCRIPTION
Fixes image blur (e.g. [here](https://www.operate-first.cloud/blueprints/continuous-delivery/docs/continuous_delivery.md)) on all images with transparent background and small pieces of content on it:

Reference: https://www.gatsbyjs.com/plugins/gatsby-remark-images/#options 

### Before
![image](https://user-images.githubusercontent.com/7453394/100426805-c3e6b500-3091-11eb-8b30-973733a2349e.png)

### After
![image](https://user-images.githubusercontent.com/7453394/100426845-cfd27700-3091-11eb-8a30-a55dbf2e8388.png)


cc @goern 