### PR TITLE
modification of href for failure-type-classification-with-the-testgrid-data-project-doc

### DIFF
--- a/config/data-science.yaml
+++ b/config/data-science.yaml
@@ -17,7 +17,7 @@
     - label: AI for Continuous Integration Overview
       href: /data-science/ocp-ci-analysis/
     - label: Failure type classification with the TestGrid
-      href: /data-science/ocp-ci-analysis/docs/publish/failure-type-classification-with-the-testgrid-data-project-doc.md
+      href: /data-science/ocp-ci-analysis/docs/failure-type-classification-with-the-testgrid-data-project-doc.md
     - label: Initial TestGrid EDA
       href: /data-science/ocp-ci-analysis/notebooks/TestGrid_EDA.ipynb
     - label: Indepth TestGrid EDA


### PR DESCRIPTION
There is a change in repo structure for doc folder in 'ocp-ci-analysis' project.
Hence,  failure-type-classification-with-the-testgrid-data-project-doc.md is not directed to correct URL.
This PR will change the href for `failure-type-classification-with-the-testgrid-data-project-doc`