### PR TITLE
modified deploy instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,14 @@ OC_PROJECT=operate-first
 OC_TOKEN=my_token
 ```
 
+Modify the image repository in the deployment config `deployment.yaml` present in `scripts/templates/base` to fetch the latest image from the location you pushed the container image to in the previous step. 
+
+Modify the following line to reflect the image repository you pushed it to. 
+
+```yaml
+image: quay.io/cfchase/operate-first-app:latest
+```
+
 Run:
 
 ```shell script


### PR DESCRIPTION
Modified the `Building site in a container` instructions by adding a step to modify deployment config to fetch from the image repository the image was pushed to in the previous step.