### PR TITLE
docs: Point to ODH Dashboard for MOC

### DIFF
--- a/config/users.yaml
+++ b/config/users.yaml
@@ -1,6 +1,2 @@
-- label: User support
+- label: Mass Open Cloud (MOC) users
   href: /users/odh-moc-support/
-- label: Components
-  links:
-    - label: JupyterHub
-      href: /users/odh-moc-support/docs/user-docs/jupyterhub.md


### PR DESCRIPTION
Requires: https://github.com/operate-first/odh-moc-support/pull/28