### PR TITLE
add weblink to node fields

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -8,6 +8,8 @@ let config = {
     title: `Operate First`,
     description: `Operate First`,
     siteUrl: `https://operate-first.cloud/`,
+    // default URL for all content within this repository for linking to the source of the content
+    srcLinkDefault: `https://github.com/operate-first/operate-first.github.io`,
   },
   plugins: [
     {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -41,6 +41,19 @@ exports.onCreateNode = ({ node, getNode, actions }) => {
       name: "slug",
       value: slug
     })
+
+    // Add the URL where the content is pulled from
+    const srcBase = gitRemoteNode ? (
+      `${gitRemoteNode.webLink}/blob/master/`
+    ) : (
+      `${getNode('Site').siteMetadata.srcLinkDefault}/blob/master/content/`
+    );
+
+    createNodeField({
+      node,
+      name: "srcLink",
+      value: srcBase + fileNode.relativePath,
+    })
   }
 }
 

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -1,11 +1,11 @@
 import React, { useState } from "react";
-import { Page } from "@patternfly/react-core";
+import { Page, PageSection, PageSectionVariants, TextContent, Button } from "@patternfly/react-core";
 import { Header, NavSidebar } from "./";
 
 import "@patternfly/patternfly/patternfly.css";
 import "./Layout.scss";
 
-export const Layout = ({ location, title, children }) => {
+export const Layout = ({ location, title, srcLink, children }) => {
   const [isNavOpen, setIsNavOpen] = useState(true);
 
   const onNavToggle = () => {
@@ -20,6 +20,13 @@ export const Layout = ({ location, title, children }) => {
       className="layout"
     >
       {children}
+      <PageSection variant={PageSectionVariants.dark}>
+        <TextContent>
+          <Button variant="primary" isLarge component="a" href={srcLink} target="_contribute">
+            Contribute to this page
+          </Button>
+        </TextContent>
+      </PageSection>
     </Page>
   );
 };

--- a/src/templates/Doc.js
+++ b/src/templates/Doc.js
@@ -17,7 +17,7 @@ export default function DocTemplate({ data: { site, mdx }, pageContext, location
 
   return (
     <Layout location={location} title={siteTitle}>
-      <SEO title={mdx.frontmatter.title} description={mdx.frontmatter.description} />
+      <SEO title={mdx.frontmatter.title} description={mdx.frontmatter.description} srcLink={mdx.fields.srcLink} />
       <PageSection className="doc" variant={PageSectionVariants.light}>
         <TextContent>
           <h1>{mdx.frontmatter.title}</h1>
@@ -40,6 +40,9 @@ export const pageQuery = graphql`
     mdx(id: { eq: $id }) {
       id
       body
+      fields {
+        srcLink
+      }
       frontmatter {
         title
         description

--- a/src/templates/JupyterNotebook.js
+++ b/src/templates/JupyterNotebook.js
@@ -9,7 +9,7 @@ import "./JupyterNotebook.scss";
 
 export default function JupyterNotebookTemplate(data) {
   return (
-    <Layout location={data.location} title={data.data.site.siteMetadata.title}>
+    <Layout location={data.location} title={data.data.site.siteMetadata.title} srcLink={data.data.jupyterNotebook.fields.srcLink}>
       <SEO title={""} description={""} />
       <PageSection className="jupyterNotebook" variant={PageSectionVariants.light}>
         <TextContent>
@@ -32,6 +32,9 @@ export const pageQuery = graphql`
     jupyterNotebook(id: { eq: $id }) {
       id
       html
+      fields {
+        srcLink
+      }
     }
   }
 `;

--- a/src/templates/Markdown.js
+++ b/src/templates/Markdown.js
@@ -12,7 +12,7 @@ export default function MarkdownTemplate({ data, pageContext, location }) {
   const md = data.markdownRemark;
 
   return (
-    <Layout location={location} title={siteTitle}>
+    <Layout location={location} title={siteTitle} srcLink={md.fields.srcLink}>
       <SEO title={md.frontmatter.title} description={md.frontmatter.description} />
       <PageSection className="doc" variant={PageSectionVariants.light}>
         <TextContent>
@@ -34,6 +34,9 @@ export const pageQuery = graphql`
     markdownRemark(id: { eq: $id }) {
       id
       html
+      fields {
+        srcLink
+      }
       frontmatter {
         title
         description


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/161888/101381403-fd4fc980-38b6-11eb-9d3e-bbe5a3db357a.png)

Add the source as a field, so that we can link to it from a page, much like a "fork me on GH" ribbon.
Any ideas on a Patternfly component? Or where to put the link? 

cc @cfchase @tumido @oindrillac 
