### PR TITLE
added entry to include flaky test detection notebook

### DIFF
--- a/config/data-science.yaml
+++ b/config/data-science.yaml
@@ -22,3 +22,5 @@
       href: /data-science/ocp-ci-analysis/notebooks/TestGrid_EDA.ipynb
     - label: Indepth TestGrid EDA
       href: /data-science/ocp-ci-analysis/notebooks/TestGrid_indepth_EDA.ipynb
+    - label: Flaky Test Detection in TestGrid
+      href: /data-science/ocp-ci-analysis/notebooks/Testgrid_flakiness_detection.ipynb


### PR DESCRIPTION
This PR address [issue](https://github.com/aicoe-aiops/ocp-ci-analysis/issues/60) 
I added entry in `data-science.yaml` file to include `Testgrid_flakiness_detection.ipynb` notebook on OperateFirst website