### PR TITLE
Add cloud price analysis content to operate first

### DIFF
--- a/config/data-science.yaml
+++ b/config/data-science.yaml
@@ -24,3 +24,14 @@
       href: /data-science/ocp-ci-analysis/notebooks/TestGrid_indepth_EDA.ipynb
     - label: Flaky Test Detection in TestGrid
       href: /data-science/ocp-ci-analysis/notebooks/Testgrid_flakiness_detection.ipynb
+- label: Cloud Price Analysis
+  links:
+    - label: Cloud Price Analysis Overview
+      href: /data-science/cloud-price-analysis/
+    - label: Forecasting Overview
+      href: /data-science/cloud-price-analysis/docs/Forecasting.md
+    - label: Intital EDA for AWS data
+      href: /data-science/cloud-price-analysis/notebooks/experimental/cloud-price-analysis-EDA.ipynb
+    - label: In-depth EDA for AWS data
+      href: /data-science/cloud-price-analysis/notebooks/experimental/cloud-price-analysis-indepth-EDA.ipynb
+

--- a/config/data-science.yaml
+++ b/config/data-science.yaml
@@ -30,8 +30,7 @@
       href: /data-science/cloud-price-analysis/
     - label: Forecasting Overview
       href: /data-science/cloud-price-analysis/docs/Forecasting.md
-    - label: Intital EDA for AWS data
+    - label: Initial EDA for AWS data
       href: /data-science/cloud-price-analysis/notebooks/experimental/cloud-price-analysis-EDA.ipynb
     - label: In-depth EDA for AWS data
       href: /data-science/cloud-price-analysis/notebooks/experimental/cloud-price-analysis-indepth-EDA.ipynb
-

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -163,6 +163,14 @@ let config = {
     {
       resolve: `gatsby-source-git`,
       options: {
+        name: `data-science/cloud-price-analysis`,
+        remote: `https://github.com/aicoe-aiops/cloud-price-analysis-public.git`,
+        patterns: [`**/*.md`, `**/*.png`, `**/*.ipynb`],
+      }
+    },
+    {
+      resolve: `gatsby-source-git`,
+      options: {
         name: `users/odh-moc-support`,
         remote: `https://github.com/operate-first/odh-moc-support.git`,
         patterns: [`**/*.md`, `**/*.png`],


### PR DESCRIPTION
This PR adds documents and notebooks for Cloud Price Analysis to Operate First Website.

Preview: https://aakankshaduggal.github.io/operate-first.github.io/data-science/cloud-price-analysis/

Fixes : [Issue1](https://github.com/aicoe-aiops/cloud-price-analysis/issues/48) and [Issue2](https://github.com/aicoe-aiops/cloud-price-analysis-public/issues/9)