### PR TITLE
update data-science.yaml and Readme with new ocp-ci project links

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add a [gatsby-source-git](https://www.gatsbyjs.com/plugins/gatsby-source-git/) s
 The `name` for the plugin will be the prefix for URLs generated from that repository.
 In the following example, all Markdown and JupyterNotebook files will be rendered as pages under the `/data-science/ocp-ci-analysis` path.
 
-The [notebooks/TestGrid_EDA.ipynb](https://github.com/aicoe-aiops/ocp-ci-analysis/blob/master/notebooks/TestGrid_EDA.ipynb) Notebook will be rendered at [/data-science/ocp-ci-analysis/notebooks/TestGrid_EDA.ipynb](http://www.operate-first.cloud/data-science/ocp-ci-analysis/notebooks/TestGrid_EDA.ipynb).
+The [notebooks/data-sources/TestGrid/testgrid_EDA.ipynb](https://github.com/aicoe-aiops/ocp-ci-analysis/blob/master/notebooks/data-sources/TestGrid/testgrid_EDA.ipynb) Notebook will be rendered at [/data-science/ocp-ci-analysis/notebooks/data-sources/TestGrid/testgrid_EDA.ipynb](http://www.operate-first.cloud/data-science/ocp-ci-analysis/notebooks/data-sources/TestGrid/testgrid_EDA.ipynb).
 
 ### Local Content
 

--- a/config/data-science.yaml
+++ b/config/data-science.yaml
@@ -17,7 +17,7 @@
     - label: AI for Continuous Integration Overview
       href: /data-science/ocp-ci-analysis/
     - label: Failure type classification with the TestGrid
-      href: /data-science/ocp-ci-analysis/notebooks/failure-type-classification/README.md
+      href: /data-science/ocp-ci-analysis/notebooks/failure-type-classification/
     - label: Initial TestGrid EDA
       href: /data-science/ocp-ci-analysis/notebooks/data-sources/TestGrid/testgrid_EDA.ipynb
     - label: Indepth TestGrid EDA

--- a/config/data-science.yaml
+++ b/config/data-science.yaml
@@ -17,13 +17,13 @@
     - label: AI for Continuous Integration Overview
       href: /data-science/ocp-ci-analysis/
     - label: Failure type classification with the TestGrid
-      href: /data-science/ocp-ci-analysis/docs/failure-type-classification-with-the-testgrid-data-project-doc.md
+      href: /data-science/ocp-ci-analysis/notebooks/failure-type-classification/README.md
     - label: Initial TestGrid EDA
-      href: /data-science/ocp-ci-analysis/notebooks/TestGrid_EDA.ipynb
+      href: /data-science/ocp-ci-analysis/notebooks/data-sources/TestGrid/testgrid_EDA.ipynb
     - label: Indepth TestGrid EDA
-      href: /data-science/ocp-ci-analysis/notebooks/TestGrid_indepth_EDA.ipynb
+      href: /data-science/ocp-ci-analysis/notebooks/data-sources/TestGrid/testgrid_indepth_EDA.ipynb
     - label: Flaky Test Detection in TestGrid
-      href: /data-science/ocp-ci-analysis/notebooks/Testgrid_flakiness_detection.ipynb
+      href: /data-science/ocp-ci-analysis/notebooks/failure-type-classification/background/testgrid_flakiness_detection.ipynb
 - label: Cloud Price Analysis
   links:
     - label: Cloud Price Analysis Overview


### PR DESCRIPTION
**THIS WILL BREAK the website! if merged before [this PR](https://github.com/aicoe-aiops/ocp-ci-analysis/pull/65) on the content source repo**. Please be sure to merge both of these PR's together.  

I have proposed a reorganization of the [ocp-ci-analysis](https://github.com/aicoe-aiops/ocp-ci-analysis) repo. The reorganization resulted in file names and locations changing a bit which will prevent the content from rendering properly on the op1st website. This PR updates all the urls on the op1st site to reflect the new changes in the content source repo. 

I have also made the proper URL changes in the readme.md where they were being used as an example.    