### PR TITLE
Add time series pages

### DIFF
--- a/config/data-science.yaml
+++ b/config/data-science.yaml
@@ -34,3 +34,11 @@
       href: /data-science/cloud-price-analysis/notebooks/experimental/cloud-price-analysis-EDA.ipynb
     - label: In-depth EDA for AWS data
       href: /data-science/cloud-price-analysis/notebooks/experimental/cloud-price-analysis-indepth-EDA.ipynb
+- label: Time series analysis for monitoring
+  links:
+    - label: Time series analysis for monitoring overview
+      href: /data-science/time-series/
+    - label: Fetching time series metrics data
+      href: /data-science/time-series/notebooks/ts-1-fetching-metrics.ipynb
+    - label: Manipulating and visualizing metrics data
+      href: /data-science/time-series/notebooks/ts-2-visualization.ipynb

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -175,6 +175,14 @@ let config = {
     {
       resolve: `gatsby-source-git`,
       options: {
+        name: `data-science/time-series`,
+        remote: `https://github.com/aicoe-aiops/time-series.git`,
+        patterns: [`**/*.md`, `**/*.png`, `**/*.ipynb`],
+      }
+    },
+    {
+      resolve: `gatsby-source-git`,
+      options: {
         name: `users/odh-moc-support`,
         remote: `https://github.com/operate-first/odh-moc-support.git`,
         patterns: [`**/*.md`, `**/*.png`],


### PR DESCRIPTION
In this PR, I add remote source for time series pages.

There are two caveats:

1) Relative links in the main page described in this [issue](https://github.com/aicoe-aiops/time-series/issues/11).
2) Rendering plotly images on the website. Currently on my local it is not able to render notebook plotly images on the website.