### PR TITLE
Add an article: Create a Jupyterhub image and deploy it on ODH.

### DIFF
--- a/config/users.yaml
+++ b/config/users.yaml
@@ -1,2 +1,6 @@
 - label: Mass Open Cloud (MOC) users
   href: /users/odh-moc-support/
+- label: Jupyterhub
+  links:
+    - label: Create a Jupyterhub image and deploy it on ODH
+      href: /users/data-science-workflows/docs/create_and_deploy_jh_image.md

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -135,6 +135,14 @@ let config = {
     {
       resolve: `gatsby-source-git`,
       options: {
+        name: `users/data-science-workflows`,
+        remote: `https://github.com/aicoe-aiops/data-science-workflows.git`,
+        patterns: [`**/*.md`, `**/*.png`],
+      }
+    },
+    {
+      resolve: `gatsby-source-git`,
+      options: {
         name: `data-science/data-science-workflows`,
         remote: `https://github.com/aicoe-aiops/data-science-workflows.git`,
         patterns: [`**/*.md`, `**/*.png`],


### PR DESCRIPTION
PR with the howto: https://github.com/aicoe-aiops/data-science-workflows/pull/24

The repository needs to be added a second time because:

 * The first time it's added with the `/data-science/` prefix.
 * Items in the left navigation are filtered by the prefix to match the top nav selection.

ping @durandom, @oindrillac 