### PR TITLE
fix: MOC repo moved to GitHub

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -180,7 +180,7 @@ let config = {
       resolve: `gatsby-source-git`,
       options: {
         name: `operators/moc-cnv-sandbox`,
-        remote: `https://gitlab.com/open-infrastructure-labs/moc-cnv-sandbox.git`,
+        remote: `https://github.com/open-infrastructure-labs/moc-cnv-sandbox.git`,
         patterns: [`**/*.md`, `**/*.png`],
       }
     },


### PR DESCRIPTION
Closes: #164 

Since https://github.com/open-infrastructure-labs/moc-cnv-sandbox was moved from https://gitlab.com/open-infrastructure-labs/moc-cnv-sandbox the content we fetched became unreachable.