### PR TITLE
Add hard drive failure prediction blog

### DIFF
--- a/config/data-science.yaml
+++ b/config/data-science.yaml
@@ -6,6 +6,8 @@
       href: /data-science/categorical-encoding/docs/blog/blog.md
     - label: Configuration File Analysis
       href: /data-science/configuration-files-analysis/docs/blog/configuration-file-analysis-blog.md
+    - label: Hard Drive Failure Prediction
+      href: /data-science/ceph-drive-failure/docs/blog/hard-drive-failure-prediction-blog.md
 - label: Data Science Workflow
   links:
     - label: Data Science Workflow Overview

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -220,6 +220,14 @@ let config = {
         patterns: [`**/*.md`, `**/*.png`],
       }
     },
+    {
+      resolve: `gatsby-source-git`,
+      options: {
+        name: `data-science/ceph-drive-failure`,
+        remote: `https://github.com/aicoe-aiops/ceph_drive_failure`,
+        patterns: [`**/*.md`, `**/*.png`, `**/*.ipynb`],
+      }
+    },
   ],
 };
 


### PR DESCRIPTION
Fixes #122 

This PR adds the project blog for hard drive prediction for ceph. Changes can be previewed [here](https://chauhankaranraj.github.io/operate-first.github.io/data-science/ceph-drive-failure/docs/blog/hard-drive-failure-prediction-blog.md).

p.s. on my fork the left nav bar does not seem to render, and looks like [others are having the same issue as well](https://github.com/operate-first/operate-first.github.io/pull/160#issuecomment-745903888).

p.p.s marking WIP at the moment since there is a typo in the blog, and aicoe-aiops/ceph_drive_failure#19 fixes that. Once that is merged, I can remove the WIP label :)