### PR TITLE
embed youtube videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ description: My Document Description
 valid markdown
 ```
 
+To add videos to Markdown follow the instructions given in [/content/examples/markdown.md#add-videos](/content/examples/markdown.md#add-videos)
+
 #### JupyterNotebook
 
 Any file with the `.ipynb` extension will be rendered as HTML. This is done via the [gatsby-transformer-ipynb](https://www.gatsbyjs.com/plugins/@rafaelquintanilha/gatsby-transformer-ipynb/).

--- a/content/examples/markdown.md
+++ b/content/examples/markdown.md
@@ -233,3 +233,10 @@ For more information, see Daring Fireball's "[Markdown Syntax](https://daringfir
 - "[About writing and formatting on GitHub](/articles/about-writing-and-formatting-on-github)"
 - "[Working with advanced formatting](/articles/working-with-advanced-formatting)"
 - "[Mastering Markdown](https://guides.github.com/features/mastering-markdown/)"
+
+### Add Videos
+
+To embed YouTube videos to Markdown, reference videos as shown [here](https://www.gatsbyjs.com/plugins/gatsby-remark-embed-video/?=video#usage).
+
+Example embedded video:
+`video: https://www.youtube.com/watch?v=jne4auRnxJ4&feature=youtu.be`

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -33,6 +33,22 @@ let config = {
         // Plugins configs
         plugins: [
           {
+            resolve: "gatsby-remark-embed-video",
+            options: {
+              width: 500,
+              ratio: 1.77, // Optional: Defaults to 16/9 = 1.77
+              related: true, //Optional: Will remove related videos from the end of an embedded YouTube video.
+              noIframeBorder: true, //Optional: Disable insertion of <style> border: 0
+              urlOverrides: [
+                {
+                  id: 'youtube',
+                  embedURL: (videoId) => `https://www.youtube-nocookie.com/embed/${videoId}`,
+                },
+              ], //Optional: Override URL of a service provider, e.g to enable youtube-nocookie support
+              containerClass: 'embedVideo-container', //Optional: Custom CSS class for iframe container, for multiple classes separate them by space
+            },
+          },
+          {
             resolve: `gatsby-remark-images`,
             options: {
               maxWidth: 590,
@@ -73,16 +89,16 @@ let config = {
         defaultLayouts: { default: path.resolve("./src/components/Layout") },
         gatsbyRemarkPlugins: [
           {
+            resolve: `gatsby-remark-responsive-iframe`,
+            options: {
+              wrapperStyle: `margin-bottom: 1.0725rem`,
+            },
+          },
+          {
             resolve: `gatsby-remark-images`,
             options: {
               maxWidth: 590,
               disableBgImageOnAlpha: true,
-            },
-          },
-          {
-            resolve: `gatsby-remark-responsive-iframe`,
-            options: {
-              wrapperStyle: `margin-bottom: 1.0725rem`,
             },
           },
           {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10288,6 +10288,48 @@
         }
       }
     },
+    "gatsby-remark-embed-video": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-embed-video/-/gatsby-remark-embed-video-3.0.10.tgz",
+      "integrity": "sha512-3dQgw0g3nndspiXkz7pKOXZs67I1Cz/sefyjXQ2bq6gtdX3qBdBurMuAeIlk0TgueMJCbR8SyFjMyVdI0LAJDg==",
+      "requires": {
+        "get-video-id": "^3.1.4",
+        "remark-burger": "^1.0.1",
+        "unist-util-visit": "^2.0.2"
+      }
+    },
+    "gatsby-remark-embed-youtube": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-embed-youtube/-/gatsby-remark-embed-youtube-0.0.7.tgz",
+      "integrity": "sha512-N+PgzQZW97ba0Hg0XaUQWbxekgASlx66WR9qCVq/ltG/pAyMGb+Lh0ls7a1JENDg+o+a3ty6gp7oKx/FbWnfOg==",
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "unist-util-visit": "^1.1.3"
+      },
+      "dependencies": {
+        "unist-util-is": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
+          "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A=="
+        },
+        "unist-util-visit": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
+          "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+          "requires": {
+            "unist-util-visit-parents": "^2.0.0"
+          }
+        },
+        "unist-util-visit-parents": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
+          "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
+          "requires": {
+            "unist-util-is": "^3.0.0"
+          }
+        }
+      }
+    },
     "gatsby-remark-images": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/gatsby-remark-images/-/gatsby-remark-images-3.7.0.tgz",
@@ -11406,6 +11448,11 @@
         "npm-conf": "^1.1.0"
       }
     },
+    "get-src": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-src/-/get-src-1.0.1.tgz",
+      "integrity": "sha1-yhHb5Kk8fzqoXOyV/LCy36qVOe4="
+    },
     "get-stdin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
@@ -11423,6 +11470,14 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+    },
+    "get-video-id": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/get-video-id/-/get-video-id-3.1.5.tgz",
+      "integrity": "sha512-jAc0aZiMava8lFJB/t/VyVKaYtcB9dVAKH/T7rjkYhnzHQ58WDlG9eKJgbzLJ+x0gPHrT87IvXkTP8tByB3ADg==",
+      "requires": {
+        "get-src": "^1.0.1"
+      }
     },
     "getpass": {
       "version": "0.1.7",
@@ -18827,6 +18882,11 @@
           }
         }
       }
+    },
+    "remark-burger": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/remark-burger/-/remark-burger-1.0.1.tgz",
+      "integrity": "sha512-F91SyEzat4hBkWsWElHIvMcCQuWoSeZXTuR4DmLvhUIjYkzzVLaX6GRxhkiDrZb/9asvTrYzwEr9HvxN1tqs9Q=="
     },
     "remark-footnotes": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "gatsby-remark-autolink-headers": "^2.7.0",
     "gatsby-remark-classes": "^1.0.0",
     "gatsby-remark-copy-linked-files": "^2.6.0",
+    "gatsby-remark-embed-video": "^3.0.10",
+    "gatsby-remark-embed-youtube": "0.0.7",
     "gatsby-remark-images": "^3.7.0",
     "gatsby-remark-prismjs": "^3.9.0",
     "gatsby-remark-responsive-iframe": "^2.7.0",


### PR DESCRIPTION
Enable embedding YouTube videos to markdown documents using the [gatsby-remark-embed-video](https://www.gatsbyjs.com/plugins/gatsby-remark-embed-video/?=video#usage) package.

YouTube videos can be embedded within markdown files like:
```
`video: https://www.youtube.com/embed/2Xc9gXyf2G4`
```
See more examples on how to reference videos [here](https://www.gatsbyjs.com/plugins/gatsby-remark-embed-video/?=video#usage).

For example:

![image](https://user-images.githubusercontent.com/32435206/103649951-4d10c780-4f2d-11eb-8050-d21349e96b73.png)

addresses #96 