### PR TITLE
Add operate-first/apps as document sources

### DIFF
--- a/config/users.yaml
+++ b/config/users.yaml
@@ -10,3 +10,9 @@
       href: /users/argocd-apps/docs/onboard_team_to_argocd.md
     - label: ArgoCD - Add an Application
       href: /users/argocd-apps/docs/add_application.md
+- label: Loki
+  links:
+    - label: How to access Loki
+      href: /users/apps/docs/observatorium/loki/README.md
+    - label: How to set up Loki as data source in Grafana
+      href: /users/apps/docs/observatorium/loki/add_loki_grafana_datasource.md

--- a/config/users.yaml
+++ b/config/users.yaml
@@ -16,3 +16,15 @@
       href: /users/apps/docs/observatorium/loki/README.md
     - label: How to set up Loki as data source in Grafana
       href: /users/apps/docs/observatorium/loki/add_loki_grafana_datasource.md
+- label: Kafka
+  links:
+    - label: How to access Kafka
+      href: /users/apps/docs/odh/kafka/README.md
+    - label: How to add Kafka topics
+      href: /users/apps/docs/odh/kafka/add_kafka_topics.md
+- label: Grafana
+  links:
+    - label: How to access Grafana
+      href: /users/apps/docs/odh/grafana/README.md
+    - label: How to add Grafana dashboards
+      href: /users/apps/docs/odh/grafana/add_grafana_dashboard.md

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -260,6 +260,14 @@ let config = {
         patterns: [`**/*.md`, `**/*.png`, `**/*.ipynb`],
       }
     },
+    {
+      resolve: `gatsby-source-git`,
+      options: {
+        name: `users/apps`,
+        remote: `https://github.com/operate-first/apps.git`,
+        patterns: [`**/*.md`, `**/*.png`],
+      }
+    },
   ],
 };
 


### PR DESCRIPTION
Link Loki, Kafka, Grafana usage docs
Closes #179 

This can be tested using:
`docker run -p 8080:8080 quay.io/4n4nd/operate-first-app:latest`