### PR TITLE
Add SRE documentation

### DIFF
--- a/config/operators.yaml
+++ b/config/operators.yaml
@@ -44,3 +44,9 @@
   links:
     - label: Getting Access
       href: /operators/moc-cnv-sandbox/docs/about-the-cluster.md
+- label: SRE (Site Reliability Engineering)
+  links:
+    - label: Setup GitHub Receiver
+      href: /operators/sre/incident-management/github-receiver-setup.md
+    - label: Configure Prometheus Alerts
+      href: /operators/sre/incident-management/configure-prometheus-alerts.md

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -284,6 +284,14 @@ let config = {
         patterns: [`**/*.md`, `**/*.png`, `**/*.ipynb`],
       }
     },
+    {
+      resolve: `gatsby-source-git`,
+      options: {
+        name: `operators/sre`,
+        remote: `https://github.com/operate-first/SRE.git`,
+        patterns: [`**/*.md`],
+      }
+    },
   ],
 };
 


### PR DESCRIPTION
This addresses #43 

The changes can be previewed [here](https://hemajv.github.io/operate-first.github.io/operators/sre/incident-management/github-receiver-setup.md) and [here](https://hemajv.github.io/operate-first.github.io/operators/sre/incident-management/configure-prometheus-alerts.md). And the nav bar should look like:

![Screenshot from 2021-02-01 17-21-08](https://user-images.githubusercontent.com/7343099/106525391-e80bab80-64b1-11eb-8d5b-24ec36395274.png)


