### PR TITLE
fix links for mailing list notebook pages

### DIFF
--- a/config/data-science.yaml
+++ b/config/data-science.yaml
@@ -51,6 +51,6 @@
     - label: Mailing List Analysis Overview
       href: /data-science/mailing-list-analysis/
     - label: Keyword Analysis
-      href: /data-science/mailing-list-analysis/notebooks/stage/contributor_analysis.ipynb
+      href: /data-science/mailing-list-analysis/notebooks/02_analyses/contributor_analysis.ipynb
     - label: Contributor Analysis
-      href: /data-science/mailing-list-analysis/notebooks/stage/keyword_analysis.ipynb
+      href: /data-science/mailing-list-analysis/notebooks/02_analyses/keyword_analysis.ipynb


### PR DESCRIPTION
We restructured the [mailing list analysis repo](https://github.com/aicoe-aiops/mailing-list-analysis-toolkit). This PR makes sure the the changes in the content repo are reflected in `config/data-science.yaml`