### PR TITLE
modified blueprint index page

### DIFF
--- a/content/blueprints/index.md
+++ b/content/blueprints/index.md
@@ -1,25 +1,5 @@
 ---
 title: Blueprints
 description: "Blueprints"
+redirect: https://www.operate-first.cloud/blueprints/blueprint/
 ---
-
-Architectural decisions
------------------------
-
-We keep track of architectural decisions using a lightweight architectural decision records. More information on the
-used format is available at https://adr.github.io/madr/. General information about architectural decision records
-is available at https://adr.github.io/ .
-
-Architectural decisions
-
-* [ADR-0000](blueprint/docs/adr/0000-use-markdown-architectural-decision-records.md) - Use Markdown Architectural Decision Records
-* [ADR-0001](blueprint/docs/adr/0001-use-gpl3-as-license.md) - Use GNU GPL as license
-* [ART-0003](blueprint/docs/adr/0003-feature-selection-policy.md) - Users of an Operate First deployment might need different features than provided by upstream project's release
-* [ART-0004](blueprint/docs/adr/0004-argocd-apps-of-apps-structure.md) - ArgoCD Apps of Apps Structure
-* [ART-0005](blueprint/docs/adr/0005-support-multi-environments-in-repos.md) - Repositories Supporting Multiple Environment Deployments
-* [ART-0006](blueprint/docs/adr/0006-monitoring-structure.md) - Application Monitoring using Prometheus
-* [ART-0007](blueprint/docs/adr/0007-alerting-setup.md) - Alerting Setup for Monitoring
-* [ART-0008](blueprint/docs/adr/0008-secrets-management.md) - GitOPS and Secrets Management
-* [ART-0009](blueprint/docs/adr/0009-cluster-resources.md) - Declarative Definitions for Cluster Scoped Resources
-* [ART-0010](blueprint/docs/adr/0010-common-auth-for-applications.md) - Common Authentication for Applications
-* [ART-0011](blueprint/docs/adr/0011-operators.md) - Managing Operators


### PR DESCRIPTION
Modified Blueprint index page to point to the source location of the content located at https://github.com/operate-first/blueprint
and this also fixes broken links.

Reverting changes in #198 