### PR TITLE
Add redirect from /telemetry to the OpenInfralabs page

### DIFF
--- a/content/telemetry/index.md
+++ b/content/telemetry/index.md
@@ -1,0 +1,5 @@
+---
+title: Telemetry Working Group
+description: "Telemetry Working Group"
+redirect: https://openinfralabs.org/telemetry/
+---


### PR DESCRIPTION
because we might mention https://www.operate-first.cloud/telemetry at RH summit and it should redirect to the landing page for the telemetry WG at https://openinfralabs.org/telemetry/