### PR TITLE
Add jupyterhub runbook to users tab

### DIFF
--- a/config/users.yaml
+++ b/config/users.yaml
@@ -2,6 +2,8 @@
   href: /users/support/
 - label: Jupyterhub
   links:
+    - label: Troubleshooting
+      href: /users/sre/runbooks/jupyterhub.md
     - label: Create a Jupyterhub image and deploy it on ODH
       href: /users/data-science-workflows/docs/create_and_deploy_jh_image.md
     - label: Elyra AIDevSecOps Tutorial

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -327,6 +327,14 @@ let config = {
         patterns: [`**/*.md`],
       }
     },
+   {
+      resolve: `gatsby-source-git`,
+      options: {
+        name: `users/sre`,
+        remote: `https://github.com/operate-first/SRE.git`,
+        patterns: [`**/*.md`],
+      }
+    },
   ],
 };
 


### PR DESCRIPTION
Add source and link for SRE repo jupyterhub runbook to users tab on the website.