### PR TITLE
fix: Apply text centering only to the front page

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -1,6 +1,7 @@
 ---
 title: Operate software in a production grade environment
 description: "Operate First for ODH"
+extraClasses: ofc-text-center
 ---
 ## What is Operate First?
 

--- a/src/templates/Markdown.js
+++ b/src/templates/Markdown.js
@@ -14,7 +14,7 @@ export default function MarkdownTemplate({ data, pageContext, location }) {
   return (
     <Layout location={location} title={siteTitle} srcLink={md.fields.srcLink}>
       <SEO title={md.frontmatter.title} description={md.frontmatter.description} />
-      <PageSection className="doc ofc-page-section-center ofc-text-center" variant={PageSectionVariants.light} isWidthLimited>
+      <PageSection className={ `doc ofc-page-section-center ${md.frontmatter.extraClasses}` } variant={PageSectionVariants.light} isWidthLimited>
         <TextContent>
           <h1>{md.frontmatter.title}</h1>
           <section dangerouslySetInnerHTML={{ __html: md.html }} />
@@ -40,6 +40,7 @@ export const pageQuery = graphql`
       frontmatter {
         title
         description
+        extraClasses
       }
     }
   }


### PR DESCRIPTION
Resolves: https://github.com/operate-first/operate-first.github.io/issues/239
Related to: https://github.com/operate-first/operate-first.github.io/pull/235#issuecomment-825918005

/cc @durandom @mcoker 