### PR TITLE
fix: Padding for all sites except frontpage

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -1,7 +1,7 @@
 ---
 title: Operate software in a production grade environment
 description: "Operate First for ODH"
-extraClasses: ofc-text-center
+extraClasses: ofc-text-center ofc-page-section-center 
 ---
 ## What is Operate First?
 

--- a/src/templates/Markdown.js
+++ b/src/templates/Markdown.js
@@ -14,7 +14,7 @@ export default function MarkdownTemplate({ data, pageContext, location }) {
   return (
     <Layout location={location} title={siteTitle} srcLink={md.fields.srcLink}>
       <SEO title={md.frontmatter.title} description={md.frontmatter.description} />
-      <PageSection className={ `doc ofc-page-section-center ${md.frontmatter.extraClasses}` } variant={PageSectionVariants.light} isWidthLimited>
+      <PageSection className={ `doc ${md.frontmatter.extraClasses}` } variant={PageSectionVariants.light} isWidthLimited>
         <TextContent>
           <h1>{md.frontmatter.title}</h1>
           <section dangerouslySetInnerHTML={{ __html: md.html }} />


### PR DESCRIPTION
Fix the horrendous padding that bubbled in from the front page 

Related to: https://github.com/operate-first/operate-first.github.io/pull/235#issuecomment-825918005
A regression left after: https://github.com/operate-first/operate-first.github.io/pull/235 not resolved by https://github.com/operate-first/operate-first.github.io/pull/240

/cc @durandom @mcoker 
### Before
![image](https://user-images.githubusercontent.com/7453394/116130258-5041e600-a6cb-11eb-8de5-e1cacf151f90.png)

### After
![image](https://user-images.githubusercontent.com/7453394/116130197-3c967f80-a6cb-11eb-8df2-0b38eb3e41aa.png)
