### PR TITLE
Add emphasis on "working in the open"

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -17,6 +17,8 @@ complexity of software stacks, the challenge is now operationalizing software.
 
 > <p>"The ability to have hands on the MOC environment while installing two open source project releases was of real value. Our teams were able to resolve critical interdependencies that the test suites had not found. I could not imagine trying to work with a customer to debug this problem."</p> <small><cite>- An operate first member</cite></small>
 
+"Operate First" is inspired by Red Hat's ["Upstream First" philosophy](https://www.redhat.com/en/blog/what-open-source-upstream), which emphasizes **working in the open**, even for Red Hat products. Operate First tries to extend "working in the open" to a part of the codebase that teams typically keep closed, even when deploying open source projects: their operations code.
+
 ## Key Personas
 
 <div class="pf-l-flex pf-m-align-items-stretch pf-m-justify-content-center pf-m-wrap">


### PR DESCRIPTION
Not everyone in the broader community is familiar with Red Hat's "upstream first" philosophy, so this PR offers a little more background and puts more emphasis on the "working in the open" part.