### PR TITLE
Add in a link to a Code of Conduct

### DIFF
--- a/src/components/Layout/Footer.js
+++ b/src/components/Layout/Footer.js
@@ -69,7 +69,7 @@ export const Footer = () => (
         target="top"
         aria-label="Code of Conduct"
       >
-        Creator of Operate-First Logo
+        Code of Conduct
       </Text>
     </GridItem>
   </Grid>

--- a/src/components/Layout/Footer.js
+++ b/src/components/Layout/Footer.js
@@ -63,6 +63,14 @@ export const Footer = () => (
       >
         Creator of Operate-First Logo
       </Text>
+        <Text
+        component={TextVariants.a}
+        href="//www.openstack.org/legal/community-code-of-conduct/"
+        target="top"
+        aria-label="Code of Conduct"
+      >
+        Creator of Operate-First Logo
+      </Text>
     </GridItem>
   </Grid>
 </footer>


### PR DESCRIPTION
If the OIF Code of Conduct is the wrong one, what is the correct one?

This should be easily findable in the footer or a main menu, depending on information architecture of the site.

I am proposing this link in this location as my best guest of what CoC to use and where to put the link.

If there should be a different CoC or location for the link, feel free to use this merge request to and patch it for the correct info.