### PR TITLE
chore: Remove martin from reviewers so he's not flooded by notifications

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,11 +5,9 @@ approvers:
   - cfchase
   - oindrillac
   - tumido
-  - martinpovolny
   - HumairAK
 reviewers:
   - hemajv
   - durandom
   - oindrillac
   - tumido
-  - martinpovolny


### PR DESCRIPTION
Let's relieve this poor man's inbox pressure! This change makes sesheta stop assigning @martinpovolny to reviews and PRs (yes, I had to tag him here for the last time :smirk: :grin: ). 