### PR TITLE
feat: Add issuing certificates to general FAQ

### DIFF
--- a/config/users.yaml
+++ b/config/users.yaml
@@ -12,6 +12,8 @@
       href: /users/support/docs/secret_management.md
     - label: Provisioning S3 buckets
       href: /users/support/docs/claiming_object_store.md
+    - label: Issuing certificates
+      href: /users/apps/docs/issuing_certificates.md
 - label: Jupyterhub
   links:
     - label: Troubleshooting


### PR DESCRIPTION
Link to this doc on website: https://github.com/operate-first/apps/blob/master/docs/issuing_certificates.md