### PR TITLE
Edits/addition to Operations page

### DIFF
--- a/content/operations/index.md
+++ b/content/operations/index.md
@@ -15,7 +15,7 @@ Operate First's mission is to adapt industry best practices around Site Reliabil
 
 ## Toolbox
 
-Toolbox is a Linux utility that provides a containerized environment in which software can be installed and used. We have created an Operate First toolbox that included tools such as Kustomize, SOPS, KSOPS, and more that can be utilized for workflows. You can find details for installing our toolbox [here][4].
+Toolbox is a Linux utility that provides a containerized environment in which software can be installed and used. We have created an Operate First toolbox that includes tools such as Kustomize, SOPS, KSOPS, and more that can be utilized for workflows. You can find details for installing our toolbox [here][4].
 
 [1]: https://www.redhat.com/en/topics/devops/what-is-gitops 
 [2]: https://sre.google/workbook/table-of-contents/

--- a/content/operations/index.md
+++ b/content/operations/index.md
@@ -3,14 +3,21 @@ title: Operations
 description: "Docs for operations related tasks and services.__"
 ---
 
-In this section you can find documentation pertaining to operations within the Operate First organization. 
+In this section, you can find documentation pertaining to operations within the Operate First initiative. 
 
 ## GitOps and Operate First
 
-In Operate First, operations span both cluster operations, as well as operations for managed services. We follow the GitOps operating model for OpenShift cluster and service management. As such we perform all operations for live deployments via GitHub pull-requests. Because of this, practically anyone can submit changes to the state of the cluster. Various applications managed by the Operate First team can also be updated in a similar manner.
+In Operate First, operations span cluster operations as well as operations for managed services. We follow the [GitOps][1] operating model for OpenShift cluster and service management. Because this model hinges on Git as a single source of truth, we perform all operations for live deployments via GitHub pull-requests. As a result, practically anyone can submit changes to the state of the cluster. Various applications managed by the Operate First team can be updated in a similar manner.
 
 ## Site Reliability Engineering
 
-The Operate First team's mission is to adapt industry best practices when it comes to SRE in an open and transparent manner. We consume practices as outlined in places like the [Google SRE book][1] and implement them in our operating framework. Here you will find resources and documentation that outline our implementation.
+Operate First's mission is to adapt industry best practices around Site Reliability Engineering (SRE) in an open and transparent manner. We consume practices as outlined in places such as the [Google SRE book][2] and implement them in our operating framework. [Here][3] you will find resources and documentation that describe our implementation.
 
-[1]: https://sre.google/workbook/table-of-contents/
+## Toolbox
+
+Toolbox is a Linux utility that provides a containerized environment in which software can be installed and used. We have created an Operate First toolbox that included tools such as Kustomize, SOPS, KSOPS, and more that can be utilized for workflows. You can find details for installing our toolbox [here][4].
+
+[1]: https://www.redhat.com/en/topics/devops/what-is-gitops 
+[2]: https://sre.google/workbook/table-of-contents/
+[3]: https://www.operate-first.cloud/operations/sre/incident-management/incident-management-procedure.md
+[4]: https://www.operate-first.cloud/operations/toolbox/README.md


### PR DESCRIPTION
This pr adds various edits on the Operate First Operations page. It also provides a bit more information on GitOps and a section for the Operate First toolbox, as well as some links to corresponding pages. Please pay special attention to the toolbox section as I want to make sure that my description is accurate.
Resolves https://github.com/operate-first/operate-first.github.io/issues/260 