### PR TITLE
feat: Make dev enviroment possible from toolbox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ endif
 
 .PHONY: dev
 dev:
-	./scripts/dev.sh
+	XDG_CONFIG_HOME=/tmp ./scripts/dev.sh
 
 ##################################
 # DEV-CLEAN - cleans local development environment


### PR DESCRIPTION
Resolves: https://github.com/operate-first/operate-first.github.io/issues/277
Requires: https://github.com/operate-first/toolbox/pull/41

If used together with `opf-toolbox:0.4.1` this PR enables a development setup wrapped within a toolbox:

<details> 
<summary>
Example <code>make dev</code> within toolbox. Click to expand:
</summary>

```sh
$ toolbox enter opf-toolbox-v0.4.1

/bin/sh: line 1: /bin/zsh: No such file or directory
makeError: command /bin/zsh not found in container opf-toolbox-v0.4.1
Using /bin/bash instead.
⬢[tcoufal@toolbox website]$ make dev
XDG_CONFIG_HOME=/tmp ./scripts/dev.sh


######## local dev ########
/home/tcoufal/Programming/AI-CoE/operate-first/website

> sharp@0.27.0 install /home/tcoufal/Programming/AI-CoE/operate-first/website/node_modules/sharp
> (node install/libvips && node install/dll-copy && prebuild-install) || (node-gyp rebuild && node install/dll-copy)

info sharp Using cached /home/tcoufal/.npm/_libvips/libvips-8.10.5-linux-x64.tar.br

> node-sass@4.14.1 install /home/tcoufal/Programming/AI-CoE/operate-first/website/node_modules/node-sass
> node scripts/install.js

Cached binary found at /home/tcoufal/.npm/node-sass/4.14.1/linux-x64-83_binding.node

> nodegit@0.27.0 install /home/tcoufal/Programming/AI-CoE/operate-first/website/node_modules/nodegit
> node lifecycleScripts/preinstall && node lifecycleScripts/install

[nodegit] Running pre-install script
[nodegit] Running install script
node-pre-gyp
WARN Using request for node-pre-gyp https download
[nodegit] Success: "/home/tcoufal/Programming/AI-CoE/operate-first/website/node_modules/nodegit/build/Release/nodegit.node" is installed via remote
[nodegit] Completed installation successfully.

> core-js@2.6.12 postinstall /home/tcoufal/Programming/AI-CoE/operate-first/website/node_modules/attr-accept/node_modules/core-js
> node -e "try{require('./postinstall')}catch(e){}"

Thank you for using core-js ( https://github.com/zloirock/core-js ) for polyfilling JavaScript standard library!

The project needs your help! Please consider supporting of core-js on Open Collective or Patreon: 
> https://opencollective.com/core-js 
> https://www.patreon.com/zloirock 

Also, the author of core-js ( https://github.com/zloirock ) is looking for a good job -)


> core-js@2.6.12 postinstall /home/tcoufal/Programming/AI-CoE/operate-first/website/node_modules/babel-runtime/node_modules/core-js
> node -e "try{require('./postinstall')}catch(e){}"


> core-js@3.8.2 postinstall /home/tcoufal/Programming/AI-CoE/operate-first/website/node_modules/core-js
> node -e "try{require('./postinstall')}catch(e){}"


> core-js-pure@3.8.3 postinstall /home/tcoufal/Programming/AI-CoE/operate-first/website/node_modules/core-js-pure
> node -e "try{require('./postinstall')}catch(e){}"


> styled-components@4.4.1 postinstall /home/tcoufal/Programming/AI-CoE/operate-first/website/node_modules/styled-components
> node ./scripts/postinstall.js || exit 0

Use styled-components at work? Consider supporting our development efforts at https://opencollective.com/styled-components

> gatsby-telemetry@1.8.0 postinstall /home/tcoufal/Programming/AI-CoE/operate-first/website/node_modules/gatsby-telemetry
> node src/postinstall.js || true


> gatsby-telemetry@1.10.0 postinstall /home/tcoufal/Programming/AI-CoE/operate-first/website/node_modules/gatsby-plugin-page-creator/node_modules/gatsby-telemetry
> node src/postinstall.js || true


> gatsby-telemetry@1.10.0 postinstall /home/tcoufal/Programming/AI-CoE/operate-first/website/node_modules/gatsby-recipes/node_modules/gatsby-telemetry
> node src/postinstall.js || true


> gatsby-telemetry@1.10.0 postinstall /home/tcoufal/Programming/AI-CoE/operate-first/website/node_modules/gatsby/node_modules/gatsby-telemetry
> node src/postinstall.js || true


> mozjpeg@7.0.0 postinstall /home/tcoufal/Programming/AI-CoE/operate-first/website/node_modules/mozjpeg
> node lib/install.js

  ✔ mozjpeg pre-build test passed successfully

> pngquant-bin@6.0.0 postinstall /home/tcoufal/Programming/AI-CoE/operate-first/website/node_modules/pngquant-bin
> node lib/install.js

  ✔ pngquant pre-build test passed successfully

> gatsby-cli@2.19.1 postinstall /home/tcoufal/Programming/AI-CoE/operate-first/website/node_modules/gatsby/node_modules/gatsby-cli
> node scripts/postinstall.js


> gatsby@2.32.3 postinstall /home/tcoufal/Programming/AI-CoE/operate-first/website/node_modules/gatsby
> node scripts/postinstall.js


> node-sass@4.14.1 postinstall /home/tcoufal/Programming/AI-CoE/operate-first/website/node_modules/node-sass
> node scripts/build.js

Binary found at /home/tcoufal/Programming/AI-CoE/operate-first/website/node_modules/node-sass/vendor/linux-x64-83/binding.node
Testing binary
Binary is fine

> nodegit@0.27.0 postinstall /home/tcoufal/Programming/AI-CoE/operate-first/website/node_modules/nodegit
> node lifecycleScripts/postinstall

npm WARN operate-first.github.io@0.1.0 license should be a valid SPDX license expression
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@1.2.13 (node_modules/webpack-dev-server/node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@1.2.13: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@1.2.13 (node_modules/watchpack-chokidar2/node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@1.2.13: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@2.3.1 (node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.3.1: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})

added 2955 packages from 1547 contributors and audited 2960 packages in 89.659s

233 packages are looking for funding
  run `npm fund` for details

found 1014 vulnerabilities (86 moderate, 926 high, 2 critical)
  run `npm audit fix` to fix them, or `npm audit` for details

> operate-first.github.io@0.1.0 start /home/tcoufal/Programming/AI-CoE/operate-first/website
> npm run develop


> operate-first.github.io@0.1.0 develop /home/tcoufal/Programming/AI-CoE/operate-first/website
> gatsby develop

success open and validate gatsby-configs - 0.340s
success load plugins - 2.742s
success onPreInit - 0.109s
success initialize cache - 0.015s
success copy gatsby files - 0.067s
success onPreBootstrap - 0.025s
success createSchemaCustomization - 0.160s
success Checking for changed pages - 0.028s
success source and transform nodes - 130.874s
warn There are conflicting field types in your data.

If you have explicitly defined a type for those fields, you can safely ignore this warning message.
Otherwise, Gatsby will omit those fields from the GraphQL schema.

If you know all field types in advance, the best strategy is to explicitly define them with the `createTypes` action, and skip inference with the `@dontInfer` directive.
See https://www.gatsbyjs.org/docs/actions/#createTypes
JupyterNotebook.json.cells.outputs.data.application/vnd.plotly.v1+json.data.x:
 - type: [date]
   value: [ ..., '2020-11-24T19:11:04.713000+00:00', ... ]
 - type: [number]
   value: [ ..., -6.508472919464111, ... ]
JupyterNotebook.json.cells.outputs.data.application/vnd.plotly.v1+json.data.y:
 - type: [string,number,number]
   value: [ '838615040', 838615040, ... ]
JupyterNotebook.json.cells.outputs.data.application/vnd.plotly.v1+json.layout.template.data.contour.colorscale:
 - type: [number,string,number]
   value: [ 0, '#0d0887', ... ]
JupyterNotebook.json.cells.outputs.data.application/vnd.plotly.v1+json.layout.template.data.heatmap.colorscale:
 - type: [number,string,number]
   value: [ 0, '#0d0887', ... ]
JupyterNotebook.json.cells.outputs.data.application/vnd.plotly.v1+json.layout.template.data.heatmapgl.colorscale:
 - type: [number,string,number]
   value: [ 0, '#0d0887', ... ]
JupyterNotebook.json.cells.outputs.data.application/vnd.plotly.v1+json.layout.template.data.histogram2d.colorscale:
 - type: [number,string,number]
   value: [ 0, '#0d0887', ... ]
JupyterNotebook.json.cells.outputs.data.application/vnd.plotly.v1+json.layout.template.data.histogram2dcontour.colorscale:
 - type: [number,string,number]
   value: [ 0, '#0d0887', ... ]
JupyterNotebook.json.cells.outputs.data.application/vnd.plotly.v1+json.layout.template.data.surface.colorscale:
 - type: [number,string,number]
   value: [ 0, '#0d0887', ... ]
JupyterNotebook.json.cells.outputs.data.application/vnd.plotly.v1+json.layout.template.layout.colorscale.diverging:
 - type: [number,string,number]
   value: [ 0, '#8e0152', ... ]
JupyterNotebook.json.cells.outputs.data.application/vnd.plotly.v1+json.layout.template.layout.colorscale.sequential:
 - type: [number,string,number]
   value: [ 0, '#0d0887', ... ]
JupyterNotebook.json.cells.outputs.data.application/vnd.plotly.v1+json.layout.template.layout.colorscale.sequentialminus:
 - type: [number,string,number]
   value: [ 0, '#0d0887', ... ]
success building schema - 83.406s
info Total nodes: 1413, SitePage nodes: 343 (use --verbose for breakdown)
success createPages - 0.652s
success Checking for changed pages - 0.001s
success createPagesStatefully - 0.265s
success update schema - 0.131s
success write out redirect data - 0.004s
success Build manifest and related icons - 0.225s
success onPostBootstrap - 0.232s
info bootstrap finished - 222.850s
success onPreExtractQueries - 0.002s
success extract queries from components - 1.017s
success write out requires - 0.029s
success run static queries - 1.201s - 5/5 4.16/s
success run page queries - 0.318s - 3/3 9.44/s
warn Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
info
Hi from the Gatsby maintainers! Based on what we see in your site, these coming
features may help you. All of these can be enabled within gatsby-config.js via
flags (samples below)

Preserve webpack's Cache (https://github.com/gatsbyjs/gatsby/discussions/28331), which changes Gatsby's cache clearing behavior to not clear webpack's
cache unless you run "gatsby clean" or delete the .cache folder manually.
Here's how to try it:

module.exports = {
  flags: { PRESERVE_WEBPACK_CACHE: true },
  plugins: [...]
}

⠀
You can now view operate-first.github.io in the browser.
⠀
  http://localhost:8000/
⠀
View GraphiQL, an in-browser IDE, to explore your site's data and schema
⠀
  http://localhost:8000/___graphql
⠀
Note that the development build is not optimized.
To create a production build, use gatsby build
⠀
success Building development bundle - 30.908s
warn The size of at least one page context chunk exceeded 500kb, which could lead to degraded performance. Consider putting less data in the page context.
``` 

</details>