### PR TITLE
feat: Display a banner from frontmatter

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -1,39 +1,22 @@
 ---
 description: "Operate First for ODH"
 extraClasses: ofc-text-center ofc-page-section-center
----
-
-<div class="above-fold-layout">
-
-  <br>
-
+banner: |
   ![Logo](logo.png "logo")
-
-  <br>
 
   ### a concept to incorporate operational experience into software projects
 
-  <br>
-  <br>
+  #### Ready to get started?
 
-  Ready to get started?
-
-  <br>
-
-  <div class="pf-l-flex pf-m-align-items-stretch pf-m-justify-content-center pf-m-wrap">
-    <div class= "ofc-gallery-card">
-      <a href="/users/support/docs/intro.md"> <button style="width: 220px; height: 75px; color: black;"><h3>I am an open source developer</h3></button></a>
-    </div>
-    <div class= "ofc-gallery-card">
-      <a href="/operations/sre/"> <button style="width: 220px; height: 75px;"><h3>I want to learn SRE practices</h3></button></a>
-    </div>
+  <div class="pf-l-flex pf-m-justify-content-center pf-m-space-items-xl pf-m-wrap">
+    <a class="pf-l-flex__item pf-c-button pf-c-button__cta-secondary pf-m-display-lg" href="/users/support/docs/intro.md">
+      <h3>I am an open source developer</h3>
+    </a>
+    <a class="pf-l-flex__item pf-c-button pf-c-button__cta-secondary pf-m-display-lg" href="/operations/sre/">
+      <h3>I want to learn SRE practices</h3>
+    </a>
   </div>
-
-  <br>
-  <br>
-</div>
-
-<br>
+---
 
 ## The Motivation
 
@@ -57,33 +40,27 @@ The result?
 
 <br>
 
-<div class="pf-l-flex pf-m-align-items-stretch pf-m-justify-content-center pf-m-wrap">
-
-  <div class="pf-c-card pf-m-flat ofc-gallery-card">
-    <div class="pf-c-card__body">
-      <i class="pf-icon pf-icon-catalog" style="font-size: 5em;"></i>
+<div class="pf-l-bullsey pf-l-flex">
+  <a class="pf-c-tile pf-c-tile pf-m-flex-1 pf-l-flex__item" style="text-decoration: none" href="/data-science/data-science-workflows/" target="_blank" tabindex="0">
+    <div class="pf-c-tile__header pf-m-stacked">
+      <div class="pf-c-tile__icon">
+        <i class="pf-icon pf-icon-catalog" style="font-size: 5em;"></i>
+      </div>
+      <div class="pf-c-tile__title">Start learning today</div>
     </div>
-    <div class="pf-c-card__body">
-      <p>Start learning today</p>
+    <div class="pf-c-tile__body"><h3>Data Science Learning Pathway</h3></div>
+  </a>
+  <a class="pf-c-tile pf-c-tile pf-m-flex-1 pf-l-flex__item" style="text-decoration: none" href="/users/support/" target="_blank">
+    <div class="pf-c-tile__header pf-m-stacked">
+      <div class="pf-c-tile__icon">
+        <i class="pf-icon pf-icon-help" style="font-size: 5em;"></i>
+      </div>
+      <div class="pf-c-tile__title">Find out about our resources</div>
     </div>
-    <div class="pf-c-card__title">
-      <small><h3><a href="/data-science/data-science-workflows/" target="_blank">Data Science Learning Pathway</a></h3></small>
-    </div>
-  </div>
-
-  <div class="pf-c-card pf-m-flat ofc-gallery-card">
-    <div class="pf-c-card__body">
-      <i class="pf-icon pf-icon-help" style="font-size: 5em;"></i>
-    </div>
-    <div class="pf-c-card__body">
-      <p>Find out about our resources</p>
-    </div>
-    <div class="pf-c-card__title">
-      <small><h3><a href="/users/support/" target="_blank">Operate First Support</a></h3></small>
-    </div>
-  </div>
-
+    <div class="pf-c-tile__body"><h3>Operate First Support</h3></div>
+  </a>
 </div>
+
 
 ## Get Involved
 

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -118,6 +118,7 @@ let config = {
         ],
       },
     },
+    'gatsby-transformer-remark-frontmatter',
     {
       resolve: `gatsby-plugin-mdx`,
       options: {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -232,3 +232,14 @@ function createPagePath(node) {
   let slug = node.slug;
   return path.join(prefix, slug);
 }
+
+exports.createSchemaCustomization = ({ actions: { createTypes } }) => {
+  createTypes(`
+    type Frontmatter @infer {
+      banner: String @md
+    }
+    type MarkdownRemark implements Node @infer {
+      frontmatter: Frontmatter!
+    }
+  `);
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -12088,6 +12088,11 @@
         }
       }
     },
+    "gatsby-transformer-remark-frontmatter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/gatsby-transformer-remark-frontmatter/-/gatsby-transformer-remark-frontmatter-1.1.0.tgz",
+      "integrity": "sha512-ZtgAmbKXjJsKNSiAqIaJbvYPNIya2F2BahvlrgLq2mHZh3QuLJ7oiOYPECcRIQ43+cLwFZITOUMAv3fo7oSXgA=="
+    },
     "gatsby-transformer-sharp": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/gatsby-transformer-sharp/-/gatsby-transformer-sharp-2.10.0.tgz",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "gatsby-source-filesystem": "^2.7.0",
     "gatsby-source-git": "^1.1.0",
     "gatsby-transformer-remark": "^2.12.0",
+    "gatsby-transformer-remark-frontmatter": "^1.1.0",
     "gatsby-transformer-sharp": "^2.5.21",
     "gatsby-transformer-yaml": "^2.7.0",
     "js-yaml": "^3.14.0",

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -13,7 +13,7 @@ import { Header, NavSidebar, Footer } from './';
 import '@patternfly/patternfly/patternfly.css';
 import './Layout.scss';
 
-export const Layout = ({ location, srcLink, children }) => {
+export const Layout = ({ location, srcLink, banner, children }) => {
   const [isNavOpen, setIsNavOpen] = useState(true);
 
   const onNavToggle = () => {
@@ -27,6 +27,13 @@ export const Layout = ({ location, srcLink, children }) => {
       isManagedSidebar
       className="layout"
     >
+      {banner && (
+        <PageSection className="banner">
+          <TextContent>
+            <section dangerouslySetInnerHTML={{ __html: banner.html }} />
+          </TextContent>
+        </PageSection>
+      )}
       {children}
       <PageSection isFilled className="ofc-text-center" variant={PageSectionVariants.dark}>
         <TextContent>
@@ -46,6 +53,9 @@ Layout.propTypes = {
   location: PropTypes.shape({
     pathname: PropTypes.string,
   }),
+  banner: PropTypes.shape({
+    html: PropTypes.string.isRequired,
+  }).isRequired,
 };
 
 export default Layout;

--- a/src/components/Layout/Layout.scss
+++ b/src/components/Layout/Layout.scss
@@ -25,20 +25,54 @@
 }
 
 .ofc-gallery-card {
-  flex: 1 1 0;
-  margin: var(--pf-global--spacer--md); // creates a gap around/between cards
-  min-width: 250px;
-  max-width: 350px;
+  margin: var(--pf-global--spacer--md);
+  padding: var(--pf-global--spacer--md);
 }
 
-.above-fold-layout {
-  background-color: black;
+.banner {
+  padding-top: 3em;
+  padding-bottom: 3em;
+  background-color: var(--pf-c-page__header--BackgroundColor);
   color: white;
-  width: 1000px;
+  text-align: center;
+
+  .pf-c-content {
+    --pf-c-content--MarginBottom: var(--pf-global--spacer--2xl);
+    --pf-c-content--h1--MarginBottom: var(--pf-global--spacer--2xl);
+    --pf-c-content--h2--MarginBottom: var(--pf-global--spacer--2xl);
+    --pf-c-content--h3--MarginBottom: var(--pf-global--spacer--2xl);
+    --pf-c-content--h4--MarginBottom: var(--pf-global--spacer--2xl);
+    color: white;
+  }
+
+  + .pf-c-page__main-section {
+    margin-top: 0;
+  }
 }
 
 .narrow-text-block {
-  width: 700px;
+  max-width: 700px;
   margin: auto;
   text-align: left;
+}
+
+.pf-c-button__cta-primary,
+.pf-c-button__cta-secondary {
+  border: 1px solid #fff;
+  font-size: 18px;
+  line-height: 27px;
+  padding: 16px 24px;
+  transition: var(--pf-global--Transition);
+}
+
+.pf-c-button__cta-primary,
+.pf-c-button__cta-secondary:hover {
+  background-color: var(--pf-global--Color--light-100);
+  color: #06c !important;
+}
+
+.pf-c-button__cta-primary:hover,
+.pf-c-button__cta-secondary {
+  background-color: transparent;
+  color: var(--pf-global--Color--light-100) !important;
 }

--- a/src/templates/Markdown.js
+++ b/src/templates/Markdown.js
@@ -24,6 +24,9 @@ export const pageQuery = graphql`
         title
         description
         extraClasses
+        banner {
+          html
+        }
       }
     }
   }
@@ -33,7 +36,12 @@ const MarkdownTemplate = ({ data: { site, markdownRemark }, location }) => {
   const siteTitle = site.siteMetadata.title;
 
   return (
-    <Layout location={location} title={siteTitle} srcLink={markdownRemark.fields.srcLink}>
+    <Layout
+      location={location}
+      title={siteTitle}
+      srcLink={markdownRemark.fields.srcLink}
+      banner={markdownRemark.frontmatter.banner}
+    >
       <SEO
         title={markdownRemark.frontmatter.title}
         description={markdownRemark.frontmatter.description}


### PR DESCRIPTION
A follow up to https://github.com/operate-first/operate-first.github.io/pull/282#pullrequestreview-730695868

This PR enables each page to define a top banner via frontmatter annotation. You can simply pass any markdown/html in there and it gets rendered on top of the page as a full size page section.

This allows us to move the top banner out of the document's `PageSection` flow and move it to a better place.

### Before:
![image](https://user-images.githubusercontent.com/7453394/129757972-646340f8-dfd8-4708-89d6-6fef37343d69.png)

### After:
![image](https://user-images.githubusercontent.com/7453394/129757905-c1c7c2a7-7762-455c-a505-6e9489846015.png)


/cc @quaid @margarethaley @oindrillac @durandom 