### PR TITLE
fix: NavSidebar invert filter

### DIFF
--- a/src/components/Layout/NavSidebar.js
+++ b/src/components/Layout/NavSidebar.js
@@ -32,7 +32,7 @@ const NavGroup = (props) => {
 
   const navItems = links
     // only include navItems that start with the current top level navigation
-    .filter(({ href }) => location.pathname.split('/')[1] !== href.split('/')[1])
+    .filter(({ href }) => location.pathname.split('/')[1] === href.split('/')[1])
     .map((node) => <NavItem key={node.id} {...node} location={location} />);
   const isActive = !!links.find((c) => location.pathname.startsWith(c.href));
 


### PR DESCRIPTION
I've broken navigation with #286 since I've moved the filter from component to the group.

In the group we want to filter only those path that belong. Previous code was `null` rendering the code that didn't belong.

This should fix it, appologies.

/cc @oindrillac  