### PR TITLE
feat: Add manual and cron based trigger to website build action

### DIFF
--- a/.github/workflows/build_job.yaml
+++ b/.github/workflows/build_job.yaml
@@ -1,35 +1,37 @@
 name: Deploy Operate First GH Pages
-on: 
-     push:
-          branches:
-              - master
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
 jobs:
-     deploy:
-          runs-on: ubuntu-latest
-          concurrency:
-              group: deploy_environment
-              cancel-in-progress: true
-          steps:
-             - uses: actions/checkout@v2
-             
-             - name: Setup Node
-               uses: actions/setup-node@v2
-               with:
-                   node-version: '12'
-               
-             - name: Dependencies
-               uses: actions/cache@v2
-               with:
-                   path: ~/.npm
-                   key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-                   restore-keys:
-                       ${{ runner.os }}-node-
+  deploy:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: deploy_environment
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v2
 
-             - run: npm ci
-             - run: npm run build
-             
-             - name: Deploy
-               uses: peaceiris/actions-gh-pages@v3
-               with: 
-                    github_token: ${{ secrets.GITHUB_TOKEN }}
-                    publish_dir: ./public
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: "12"
+
+      - name: Dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-node-
+
+      - run: npm ci
+      - run: npm run build
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public


### PR DESCRIPTION
- Fix formatting to something less verbose and more compact (standard 2 spaces)
- Add manual trigger via `workflow_dispatch`
- Add cron trigger for every day