### PR TITLE
chore: Force different actor on deploy workflow schedule trigger

### DIFF
--- a/.github/workflows/build_job.yaml
+++ b/.github/workflows/build_job.yaml
@@ -32,6 +32,17 @@ jobs:
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.event_name != "schedule" }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public
+
+      - name: Deploy (scheduled)
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.event_name == "schedule" }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public
+          user_name: "github-actions[bot]"
+          user_email: "github-actions[bot]@users.noreply.github.com"
+          commit_message: "deploy (scheduled): "


### PR DESCRIPTION
TIL that GitHub actions uses the last editor of the cron schedule as the GitHub action actor.

https://github.community/t/who-will-be-the-github-actor-when-a-workflow-runs-on-a-schedule/17369

I've noticed that scheduled deploy runs are creating activity on my GH account - creating commits in my name, since I'm the last user that edited the `schedule`... Let's change that, so the actor is forced to `github-actions[bot]` on the scheduled runs while it remains variable for the push/manual triggers to the actual changeset authors.

![image](https://user-images.githubusercontent.com/7453394/148064446-a543a6a7-1b81-4402-b4f6-e2f80fce45e3.png)

![image](https://user-images.githubusercontent.com/7453394/148064566-0f7c4ef5-8db3-4f54-b86d-e85b2ef2cb3e.png)

Uses:
https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-set-git-username-and-email
https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-set-custom-commit-message
https://docs.github.com/en/actions/learn-github-actions/expressions
https://docs.github.com/en/actions/learn-github-actions/contexts#github-context