### PR TITLE
chore: Fix github action syntax

### DIFF
--- a/.github/workflows/build_job.yaml
+++ b/.github/workflows/build_job.yaml
@@ -32,14 +32,14 @@ jobs:
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
-        if: ${{ github.event_name != "schedule" }}
+        if: ${{ github.event_name != 'schedule' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public
 
       - name: Deploy (scheduled)
         uses: peaceiris/actions-gh-pages@v3
-        if: ${{ github.event_name == "schedule" }}
+        if: ${{ github.event_name == 'schedule' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public


### PR DESCRIPTION
I think I broke Github Actions with #341 
![image](https://user-images.githubusercontent.com/7453394/148954308-2b31161c-da9a-4db9-a08e-8e24ed370381.png)

I think the problem is `"` instead of `'`...