### PR TITLE
Clean up community page

### DIFF
--- a/content/community/index.md
+++ b/content/community/index.md
@@ -1,6 +1,6 @@
 # Operate First Community
 
-## Who are we?
+### Who are we?
 
 We are data scientists, software engineers and DevOps professionals working
 within the Operate First framework on open source software with open
@@ -8,14 +8,29 @@ infrastructure, focused on solving large scale operational issues around
 developing intelligent applications and managing hybrid cloud systems through
 the application of advanced automation and machine learning.
 
-## Join us!
+### Join us!
 
-Get in touch with us via [Slack][], follow our [Twitter][], or view community
-project demos and updates on our [YouTube]()
+Find our code on [GitHub][], meet the community on [Slack][], and join our
+mailing lists for announcements and discussions:
 
+[github]: https://github.com/operate-first
 [slack]: https://join.slack.com/t/operatefirst/shared_invite/zt-o2gn4wn8-O39g7sthTAuPCvaCNRnLww
-[youtube]: https://www.youtube.com/channel/UCe87bwqlGoBQs2RvMQZ5_sg
+
+- [Community][] mailing list for Operate First project user and contributor
+  discussions
+- [Announcements][] list for the latest project news
+- [OpenInfra Labs][] mailing list for those interested in open source cloud
+  operations more broadly
+
+[community]: https://lists.operate-first.cloud/admin/lists/community.lists.operate-first.cloud/
+[announcements]: https://lists.operate-first.cloud/admin/lists/announcements.lists.operate-first.cloud/
+[openinfra labs]: http://lists.opendev.org/cgi-bin/mailman/listinfo/openinfralabs
+
+You can also find us on [Twitter][], or view community project demos and
+updates on our [YouTube][].
+
 [twitter]: https://twitter.com/operatefirst
+[youtube]: https://www.youtube.com/channel/UCe87bwqlGoBQs2RvMQZ5_sg
 
 If you're interested in data science, check out our [data science projects][].
 If you are more interested in site reliability engineering, we have [SRE

--- a/content/community/index.md
+++ b/content/community/index.md
@@ -1,11 +1,25 @@
 # Operate First Community
 
-### **Who are we?**
+## Who are we?
 
-We are data scientists, software engineers and DevOps professionals working within the Operate First framework on open source software with open infrastructure, focused on solving large scale operational issues around developing intelligent applications and managing hybrid cloud systems through the application of advanced automation and machine learning.
+We are data scientists, software engineers and DevOps professionals working
+within the Operate First framework on open source software with open
+infrastructure, focused on solving large scale operational issues around
+developing intelligent applications and managing hybrid cloud systems through
+the application of advanced automation and machine learning.
 
-### **Join us!**
+## Join us!
 
-Get in touch with us via [Slack](https://join.slack.com/t/operatefirst/shared_invite/zt-o2gn4wn8-O39g7sthTAuPCvaCNRnLww), follow our [Twitter](https://twitter.com/operatefirst), or view community project demos and updates on our [YouTube](https://www.youtube.com/channel/UCe87bwqlGoBQs2RvMQZ5_sg)
+Get in touch with us via [Slack][], follow our [Twitter][], or view community
+project demos and updates on our [YouTube]()
 
-If you're interested in data science, check out our [data science projects](/data-science/projectsoverview.md). If you are more interested in site reliabilty engineering, we have [SRE resources](/operations/sre/README.md) to help you get started!
+[slack]: https://join.slack.com/t/operatefirst/shared_invite/zt-o2gn4wn8-O39g7sthTAuPCvaCNRnLww
+[youtube]: https://www.youtube.com/channel/UCe87bwqlGoBQs2RvMQZ5_sg
+[twitter]: https://twitter.com/operatefirst
+
+If you're interested in data science, check out our [data science projects][].
+If you are more interested in site reliability engineering, we have [SRE
+resources][] to help you get started!
+
+[data science projects]: /data-science/projectsoverview.md
+[sre resources]: /operations/sre/README.md


### PR DESCRIPTION
- Update community page to include mailing list links

  This copies the "get involved" text from the main page and drops it onto the community page, since that's where people might look for it.

- Clean up community page markdown

  - Wrap lines
  - Replace inline links with reference links
  - Fix heading levels

