### PR TITLE
Fix broken link to community handbook

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -50,7 +50,7 @@ The result?
     </div>
     <div class="pf-c-tile__body"><h3>Data Science Learning Pathway</h3></div>
   </a>
-  <a class="pf-c-tile pf-c-tile pf-m-flex-1 pf-l-flex__item" style="text-decoration: none" href="/hitchhikers-guide/support/README.md" target="_blank">
+  <a class="pf-c-tile pf-c-tile pf-m-flex-1 pf-l-flex__item" style="text-decoration: none" href="/community-handbook/support/README.md" target="_blank">
     <div class="pf-c-tile__header pf-m-stacked">
       <div class="pf-c-tile__icon">
         <i class="pf-icon pf-icon-help" style="font-size: 5em;"></i>


### PR DESCRIPTION
The main page was pointing to /hitchhikers-guide instead of
/community-handbook

Closes operate-first/support#517
