### PR TITLE
Removal of Zero Cluster from cluster drop down

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -154,10 +154,6 @@ module.exports = {
         name: 'MOC',
         clusters: [
           {
-            name: 'Zero',
-            url: 'http://console-openshift-console.apps.zero.massopen.cloud/',
-          },
-          {
             name: 'Infra',
             url: 'http://console-openshift-console.apps.moc-infra.massopen.cloud/',
           },


### PR DESCRIPTION
The cluster drop down on the main page still showed MOC-Zero in the cluster drop-down.

### Issue:
Resolves issue [#359 ](https://github.com/operate-first/operate-first.github.io/issues/359)