### PR TITLE
Replaced broken emoji shortcode

### DIFF
--- a/content/data-science/index.md
+++ b/content/data-science/index.md
@@ -1,6 +1,6 @@
 # Cloud Native Data Science and AI Ops:</br> *With Operate-First!*
 
-**Ready to help build the next generation of intelligent applications for the cloud, *IN* the cloud?** :sunglasses:
+**Ready to help build the next generation of intelligent applications for the cloud, *IN* the cloud?** 😎
 
 ### **Who are we?**
 


### PR DESCRIPTION
## Description:
For some reason the :sunglasses: emoji shortcut seems to not showing on https://www.operate-first.cloud/data-science
- Swapped with unicode emoji,  which is supported in markdown

If you want to learn more about markdown and emojis go [here](https://www.markdownguide.org/extended-syntax/#:~:text=Many%20Markdown%20applications%20will%20automatically,application%20should%20display%20the%20emoji.)

## Issue:
Resolves issue #358 