### PR TITLE
Better looking 404

### DIFF
--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -6,14 +6,24 @@ import { graphql } from 'gatsby';
 import Layout from '../components/Layout';
 import SEO from '../components/seo';
 
+import { Link } from 'gatsby';
+import SlackIcon from '@patternfly/react-icons/dist/esm/icons/slack-icon';
+
 const NotFoundPage = ({ data, location }) => {
   const siteTitle = data.site.siteMetadata.title;
 
   return (
     <Layout location={location} title={siteTitle}>
       <SEO title="404: Not Found" />
-      <h1>Not Found</h1>
-      <p>You just hit a route that doesn&#39;t exist... the sadness.</p>
+        <div style={{textAlign: 'center', marginTop: '2em', marginBottom: '2em'}}>
+            <b style={{fontSize: "1.5em"}}>Page not found</b>
+            <br />
+            <img style={{width: "100px"}}src="https://www.patternfly.org/v4/images/404.235047dd57c8e5d52f224e2e0cd6f5ae.svg" />
+            <p>You just hit a route that doesn&#39;t exist... the sadness 😢</p>
+            <p>For any questions reach out to us on <a href="https://join.slack.com/t/operatefirst/shared_invite/zt-o2gn4wn8-O39g7sthTAuPCvaCNRnLww">Slack</a>
+            </p>
+            <Link to={`/`}>Return to homepage</Link>
+        </div>
     </Layout>
   );
 };


### PR DESCRIPTION
## Description:
Currently our 404 a bit of an improvement

**Changes**:
- Imported `link` from gatsby, and added Link component to route back to
  homepage
- Added recommended image to 404 message
- Added an emoji to emphasize sadness :(
- Inline styling to improve look (margins)

## Issue: 
Resolves issue #176 

## Images:
**Desktop: 1920x1080p**
![image](https://user-images.githubusercontent.com/68972382/155406181-a5e58e8a-43a7-4783-9116-2542809cb73c.png)
**Mobile: iPhone X**
![image](https://user-images.githubusercontent.com/68972382/155406350-9114a24e-28e2-4d08-8fb3-108c3328a431.png)

## Note:
Feel free to make reviews, suggestions, etc