### PR TITLE
Added quick links section and website WG section

### DIFF
--- a/content/community-handbook/index.md
+++ b/content/community-handbook/index.md
@@ -1,4 +1,11 @@
-## Welcome to the hitchhiker's guide to Operate First!
+# Welcome to the hitchhiker's guide to Operate First!
 
 Hitchhiker's guide is intended to serve as a main resource for all Operate First community contributors. It contains
 documentation on how to perform contributor-related tasks and encourages input and contributions from the community.
+
+## Want to contribute to the website?
+Check out the Operate First [SIG-Community repository](https://github.com/operate-first/community). There you can learn more about our community along with information about our sub-projects and working groups. We currently have a [Website Working Group](https://github.com/operate-first/community/tree/main/sig-community) working on improving the website; if you would like to contribute, join the [Operate First Slack](https://join.slack.com/t/operatefirst/shared_invite/zt-o2gn4wn8-O39g7sthTAuPCvaCNRnLww), specifically the `#websites-updates-wg` channel.
+
+### Quick Links
+- [GitOps Documentation](https://www.operate-first.cloud/apps/content/README.html)
+- [Operate First Apps Repository](https://github.com/operate-first/apps)


### PR DESCRIPTION
## Description:
In conjunction to the **Website Updates WG** future changes this PR is here to help ease navigation in the meantime. 

The goal of this PR is have a section in the **Community Handbook** landing-page which informs user about the SIG-Community along with the Website Updates working group. Also to market the working group to gain contributors.
#### Changes
- Added **Contribution** section
- Added quick links for user convenience
    - GitOps Docs, now one less click to reach the docs
    - Apps Repo, to find the main repo of the Operate First environment
## Demo:
![image](https://user-images.githubusercontent.com/68972382/158244159-c3971b35-ba68-4ec9-be0a-cb625cb7132c.png)

Feel free to request changes, and let me know if you would like to see any other links to the **Quick Links** section
